### PR TITLE
Apply port speed again after disabling port AN

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -3515,6 +3515,7 @@ void PortsOrch::doPortTask(Consumer &consumer)
 
         if (op == SET_COMMAND)
         {
+            bool apply_port_speed_on_an_change_to_disabled = false;
             auto &fvMap = m_portConfigMap[key];
 
             for (const auto &cit : kfvFieldsValues(keyOpFieldsValues))
@@ -3713,6 +3714,18 @@ void PortsOrch::doPortTask(Consumer &consumer)
                             "Set port %s autoneg to %s",
                             p.m_alias.c_str(), m_portHlpr.getAutonegStr(pCfg).c_str()
                         );
+
+                        /* Reapply port speed after AN disabled */
+                        if (p.m_autoneg < 1)
+                        {
+                            if (pCfg.speed.is_set != true)
+                            {
+                                pCfg.speed.is_set = true;
+                                pCfg.speed.value = p.m_speed;
+                            }
+                            /* Force update speed even if p.m_speed == pCfg.speed.value */
+                            apply_port_speed_on_an_change_to_disabled = true;
+                        }
                     }
                 }
 
@@ -3772,7 +3785,7 @@ void PortsOrch::doPortTask(Consumer &consumer)
 
                 if (pCfg.speed.is_set)
                 {
-                    if (p.m_speed != pCfg.speed.value)
+                    if (p.m_speed != pCfg.speed.value || apply_port_speed_on_an_change_to_disabled)
                     {
                         if (!isSpeedSupported(p.m_alias, p.m_port_id, pCfg.speed.value))
                         {


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Apply port speed again after disabling port AN.

In PortsOrch, when autonegotiation is disabled for a port, this PR ensures
that the port speed is updated correctly. If a new speed is configured while
autonegotiation is disabled, the new speed is applied; otherwise, the current
speed setting is reconfigured.

**Why I did it**
In PortsOrch, the port speed configuration will not be set to SAI when port AN is enabled.
Changing the port speed while port AN is enabled will not take effect after port AN is disabled.

In some chips, the port speed can not be modified when port AN is enabled.

**How I verified it**

1. Enable port AN.
2. Set port speed from speed1 to speed2
3. Disable port AN.
4. Make sure port speed is speed2 instead of speed1.

**Details if related**
https://github.com/sonic-net/sonic-swss/pull/3094