### PR TITLE
Initialize port autoneg status.

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -5321,8 +5321,11 @@ bool PortsOrch::initializePort(Port &port)
         return false;
     }
 
+    /* initialize port autoneg status */
+    port.m_autoneg = isAutoNegEnabled(port.m_port_id);
+
     /* initialize port admin speed */
-    if (!isAutoNegEnabled(port.m_port_id) && !getPortSpeed(port.m_port_id, port.m_speed))
+    if (!port.m_autoneg && !getPortSpeed(port.m_port_id, port.m_speed))
     {
         SWSS_LOG_ERROR("Failed to get initial port admin speed %d", port.m_speed);
         return false;


### PR DESCRIPTION
Initialize port.m_autoneg from chip AN setting.

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Initialize port.m_autoneg from chip AN setting.

**Why I did it**
Sinc the auto-negotiation status is initialized, update port.m_autoneg.

**How I verified it**

**Details if related**
