### PR TITLE
Remove the API setBridgePortLearningFDB() and use setBridgePortLearnMode() only

### DIFF
--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -857,7 +857,13 @@ void OrchDaemon::start()
                         for (auto& pair: gPortsOrch->getAllPorts())
                         {
                             auto& port = pair.second;
-                            gPortsOrch->setBridgePortLearningFDB(port, SAI_BRIDGE_PORT_FDB_LEARNING_MODE_DISABLE);
+                            // TODO: how to support 1D bridge?
+                            if (port.m_type != Port::PHY && port.m_type != Port::LAG)
+                            {
+                                continue;
+                            }
+
+                            gPortsOrch->setBridgePortLearnMode(port, SAI_BRIDGE_PORT_FDB_LEARNING_MODE_DISABLE);
                         }
                     }
 

--- a/orchagent/p4orch/tests/fake_portorch.cpp
+++ b/orchagent/p4orch/tests/fake_portorch.cpp
@@ -63,7 +63,7 @@ bool PortsOrch::getBridgePort(sai_object_id_t id, Port &port)
     return true;
 }
 
-bool PortsOrch::setBridgePortLearningFDB(Port &port, sai_bridge_port_fdb_learning_mode_t mode)
+bool PortsOrch::setBridgePortLearnMode(Port &port, sai_bridge_port_fdb_learning_mode_t learn_mode)
 {
     return true;
 }
@@ -439,11 +439,6 @@ bool PortsOrch::addHostIntfs(Port &port, string alias, sai_object_id_t &host_int
 }
 
 bool PortsOrch::setHostIntfsStripTag(Port &port, sai_hostif_vlan_tag_t strip)
-{
-    return true;
-}
-
-bool PortsOrch::setBridgePortLearnMode(Port &port, sai_bridge_port_fdb_learning_mode_t learn_mode)
 {
     return true;
 }

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -5479,31 +5479,6 @@ ReturnCode PortsOrch::removeSendToIngressHostIf()
     return ReturnCode();
 }
 
-bool PortsOrch::setBridgePortLearningFDB(Port &port, sai_bridge_port_fdb_learning_mode_t mode)
-{
-    // TODO: how to support 1D bridge?
-    if (port.m_type != Port::PHY) return false;
-
-    auto bridge_port_id = port.m_bridge_port_id;
-    if (bridge_port_id == SAI_NULL_OBJECT_ID) return false;
-
-    sai_attribute_t bport_attr;
-    bport_attr.id = SAI_BRIDGE_PORT_ATTR_FDB_LEARNING_MODE;
-    bport_attr.value.s32 = mode;
-    auto status = sai_bridge_api->set_bridge_port_attribute(bridge_port_id, &bport_attr);
-    if (status != SAI_STATUS_SUCCESS)
-    {
-        SWSS_LOG_ERROR("Failed to set bridge port %" PRIx64 " learning_mode attribute: %d", bridge_port_id, status);
-        task_process_status handle_status = handleSaiSetStatus(SAI_API_BRIDGE, status);
-        if (handle_status != task_success)
-        {
-            return parseHandleSaiStatusFailure(handle_status);
-        }
-    }
-    SWSS_LOG_NOTICE("Disable FDB learning on bridge port %s(%" PRIx64 ")", port.m_alias.c_str(), bridge_port_id);
-    return true;
-}
-
 bool PortsOrch::addBridgePort(Port &port)
 {
     SWSS_LOG_ENTER();

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -132,7 +132,7 @@ public:
     bool bake() override;
     void cleanPortTable(const vector<string>& keys);
     bool getBridgePort(sai_object_id_t id, Port &port);
-    bool setBridgePortLearningFDB(Port &port, sai_bridge_port_fdb_learning_mode_t mode);
+    bool setBridgePortLearnMode(Port &port, sai_bridge_port_fdb_learning_mode_t learn_mode);
     bool getPort(string alias, Port &port);
     bool getPort(sai_object_id_t id, Port &port);
     void increasePortRefCount(const string &alias);
@@ -364,8 +364,6 @@ private:
 
     bool addHostIntfs(Port &port, string alias, sai_object_id_t &host_intfs_id);
     bool setHostIntfsStripTag(Port &port, sai_hostif_vlan_tag_t strip);
-
-    bool setBridgePortLearnMode(Port &port, sai_bridge_port_fdb_learning_mode_t learn_mode);
 
     bool addVlan(string vlan);
     bool removeVlan(Port vlan);


### PR DESCRIPTION
**What I did**
1.Remove the API setBridgePortLearningFDB()
2.Use setBridgePortLearnMode() as instead
3.Set L2 LAG's learning mode to forward during swss warm restart

**Why I did it**
Two API setBridgePortLearningFDB() and setBridgePortLearnMode() do the same thing which configured port learning mode.
The code can be refined to have only one API.