### PR TITLE
[Bridge] Disable MAC learning for Link Local Mulitcast Frames on the kernel bridge

### DIFF
--- a/cfgmgr/vlanmgr.cpp
+++ b/cfgmgr/vlanmgr.cpp
@@ -113,6 +113,16 @@ VlanMgr::VlanMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, c
 
         EXEC_WITH_ERROR_THROW(echo_cmd_backup, res);
     }
+
+    // not learn from link-local frames
+    // /bin/echo 1 > /sys/class/net/Bridge/bridge/no_linklocal_learn
+    const std::string no_ll_learn_cmd = std::string("")
+      + ECHO_CMD + " 1 > /sys/class/net/" + DOT1Q_BRIDGE_NAME + "/bridge/no_linklocal_learn";
+
+    ret = swss::exec(no_ll_learn_cmd, res);
+    if (ret) {
+        SWSS_LOG_ERROR("Command '%s' failed with rc %d", no_ll_learn_cmd.c_str(), ret);
+    }
 }
 
 bool VlanMgr::addHostVlan(int vlan_id)


### PR DESCRIPTION
**What I did**
[Bridge] Disable MAC learning for Link Local Mulitcast Frames on the kernel bridge
Disable the MAC learning for the frame with 01:08:c2:xx:xx:xx DA

**Why I did it**
To prevent MAC flapping in different ports by control packet, such as LLDP

**How I verified it**
Connect 2 DUTs with 2 ports in same VLAN. Check the linux MAC address table by `sudo bridge fdb show`

**Details if related**
