### PR TITLE
[intfmgrd] Flush IPv4 link local neighbors while removing router intf

### DIFF
--- a/cfgmgr/intfmgr.h
+++ b/cfgmgr/intfmgr.h
@@ -19,6 +19,11 @@ struct SubIntfInfo
 
 typedef std::map<std::string, SubIntfInfo>             SubIntfMap;
 
+enum class IpVersion {
+    IPv4,
+    IPv6
+};
+
 namespace swss {
 
 class IntfMgr : public Orch
@@ -68,7 +73,8 @@ private:
     void removeHostSubIntf(const std::string &subIntf);
     void setSubIntfStateOk(const std::string &alias);
     void removeSubIntfState(const std::string &alias);
-    void delIpv6LinkLocalNeigh(const std::string &alias);
+    void execNeighDelCommand(const std::string& cmd);
+    void delLinkLocalNeigh(const std::string &alias, IpVersion ipVersion);
 
     bool setIntfProxyArp(const std::string &alias, const std::string &proxy_arp);
     bool setIntfGratArp(const std::string &alias, const std::string &grat_arp);


### PR DESCRIPTION
[intfmgrd] Flush IPv4 link local neighbors while removing router intf

**What I did**
When removing the router interface, ensure to also flush the IPv4 Link-Local neighbors.
If there is no IP address on the router interface, the IPv4 Link-Local neighbors may
not automatically disappear. This can prevent the failure removal of the router interface
due to it being referenced by the neighbor entries.


**Why I did it**

**How I verified it**

**Details if related**
