### PR TITLE
[neighsync] Ignore neighbor entries on non-router-interface

### DIFF
--- a/neighsyncd/neighsync.h
+++ b/neighsyncd/neighsync.h
@@ -39,9 +39,11 @@ private:
     Table m_stateNeighRestoreTable, m_cfgPeerSwitchTable;
     ProducerStateTable m_neighTable;
     AppRestartAssist  *m_AppRestartAssist;
-    Table m_cfgVlanInterfaceTable, m_cfgLagInterfaceTable, m_cfgInterfaceTable;
+    Table m_cfgVlanInterfaceTable, m_cfgLagInterfaceTable, m_cfgInterfaceTable, m_cfgSubInterfaceTable;
 
     bool isLinkLocalEnabled(const std::string &port);
+    Table* getInterfaceTable(const std::string &intfName);
+    bool isRouterInterface(const std::string &intfName);
 };
 
 }


### PR DESCRIPTION

**What I did**
To prevent learning neighbor on the non-router interface.

**Why I did**
Ensure that the VRF can be added and deleted successfully.

**How I verified it**
Run VRF auto.

