### PR TITLE
Increase vlan fdbcount when the fdbentry doesn't exist and receive port move event.

### DIFF
--- a/orchagent/fdborch.cpp
+++ b/orchagent/fdborch.cpp
@@ -531,13 +531,21 @@ void FdbOrch::update(sai_fdb_event_t        type,
         update.add = false;
         if (!update.port.m_alias.empty())
         {
-            update.port.m_fdb_count--;
-            m_portsOrch->setPort(update.port.m_alias, update.port);
+            if (update.port.m_fdb_count > 0)
+            {
+                update.port.m_fdb_count--;
+                m_portsOrch->setPort(update.port.m_alias, update.port);
+            }
         }
         if (!vlan.m_alias.empty())
         {
-            vlan.m_fdb_count--;
-            m_portsOrch->setPort(vlan.m_alias, vlan);
+            if (vlan.m_fdb_count > 0)
+            {
+                vlan.m_fdb_count--;
+                m_portsOrch->setPort(vlan.m_alias, vlan);
+            }
+            else
+                SWSS_LOG_ERROR("%s fdbcount is 0, can't remove, FDB %s", vlan.m_alias.c_str(), update.entry.mac.to_string().c_str());
         }
         storeFdbEntryState(update);
 
@@ -559,7 +567,9 @@ void FdbOrch::update(sai_fdb_event_t        type,
         {
              SWSS_LOG_WARN("FdbOrch MOVE notification: mac %s is not found in bv_id 0x%" PRIx64,
                     update.entry.mac.to_string().c_str(), entry->bv_id);
-            break;
+             vlan.m_fdb_count++;
+             m_portsOrch->setPort(vlan.m_alias, vlan);
+             break;
         }
         else if (!m_portsOrch->getPortByBridgePortId(existing_entry->second.bridge_port_id, port_old))
         {
@@ -1669,10 +1679,22 @@ bool FdbOrch::removeFdbEntry(const FdbEntry& entry, FdbOrigin origin)
     SWSS_LOG_INFO("Removed mac=%s bv_id=0x%" PRIx64 " port:%s",
             entry.mac.to_string().c_str(), entry.bv_id, port.m_alias.c_str());
 
-    port.m_fdb_count--;
-    m_portsOrch->setPort(port.m_alias, port);
-    vlan.m_fdb_count--;
-    m_portsOrch->setPort(vlan.m_alias, vlan);
+    if (port.m_fdb_count > 0)
+    {
+        port.m_fdb_count--;
+        m_portsOrch->setPort(port.m_alias, port);
+    }
+    else
+        SWSS_LOG_ERROR("%s fdbcount is 0, can't remove, FDB %s", port.m_alias.c_str(), entry.mac.to_string().c_str());
+
+    if (vlan.m_fdb_count > 0)
+    {
+        vlan.m_fdb_count--;
+        m_portsOrch->setPort(vlan.m_alias, vlan);
+    }
+    else
+        SWSS_LOG_ERROR("%s fdbcount is 0, can't remove, FDB %s", vlan.m_alias.c_str(), entry.mac.to_string().c_str());
+
     (void)m_entries.erase(entry);
 
     // Remove in StateDb


### PR DESCRIPTION

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Increase vlan fdbcount when the fdbentry doesn't exist and receive port move event.

**Why I did it**

receive port move event, but the mac doesn't exist on fdborch and asic db.
**How I verified it**

run evpn sonic-mgmt test
**Details if related**
