### PR TITLE
JIRA-JRTC-7979: [neighsync] Modifcatoin for ignoring neighbor entries

### DIFF
--- a/neighsyncd/neighsync.cpp
+++ b/neighsyncd/neighsync.cpp
@@ -20,6 +20,9 @@
 using namespace std;
 using namespace swss;
 
+#define VLAN_SUB_INTERFACE_SEPARATOR   "."
+#define RESERVED_IPV4_LL    "169.254.0.1"
+
 NeighSync::NeighSync(RedisPipeline *pipelineAppDB, DBConnector *stateDb, DBConnector *cfgDb) :
     m_neighTable(pipelineAppDB, APP_NEIGH_TABLE_NAME),
     m_stateNeighRestoreTable(stateDb, STATE_NEIGH_RESTORE_TABLE_NAME),
@@ -88,7 +91,6 @@ bool NeighSync::isRouterInterface(const std::string &intfName)
 {
     vector<FieldValueTuple> values;
     Table *intfTable_p = nullptr;
-
     intfTable_p = getInterfaceTable(intfName);
     if ((intfTable_p != nullptr) && intfTable_p->get(intfName, values))
     {
@@ -102,6 +104,7 @@ void NeighSync::onMsg(int nlmsg_type, struct nl_object *obj)
     char ipStr[MAX_ADDR_SIZE + 1] = {0};
     char macStr[MAX_ADDR_SIZE + 1] = {0};
     struct rtnl_neigh *neigh = (struct rtnl_neigh *)obj;
+    struct nl_addr *lladdr = NULL;
     string key;
     string family;
     string intfName;
@@ -175,8 +178,14 @@ void NeighSync::onMsg(int nlmsg_type, struct nl_object *obj)
 	    delete_key = true;
     }
 
-    /* Ignore neighbor entries on non-router-interface */
-    if (!delete_key && !isRouterInterface(intfName))
+    /* Ignore the following neighbor entries
+     * - learned on non-router interface
+     * - learned on SAG disabled interface
+     * For reserved IPv4 link-local address (169.254.0.1) used as next hop for BGP unnumber,
+     * this entry shouldn't be ignored even if it satisfy the above condition
+     * */
+    //if (!delete_key && !isRouterInterface(intfName) && !isSagEnabled(intfName) && strcmp(ipStr, RESERVED_IPV4_LL)) ///FIXME, isSagEnabled
+    if (!delete_key && !isRouterInterface(intfName) && strcmp(ipStr, RESERVED_IPV4_LL))
     {
         SWSS_LOG_INFO("Ignore neighbor %s on non-router-interface %s", ipStr, intfName.c_str());
         return;
@@ -189,7 +198,14 @@ void NeighSync::onMsg(int nlmsg_type, struct nl_object *obj)
     }
     else
     {
-        nl_addr2str(rtnl_neigh_get_lladdr(neigh), macStr, MAX_ADDR_SIZE);
+        /* Get the link-layer address */
+        lladdr = rtnl_neigh_get_lladdr(neigh);
+
+        /* Check if the link-layer address is NULL */
+        if (lladdr != NULL)
+        {
+            nl_addr2str(lladdr, macStr, MAX_ADDR_SIZE);
+        }
     }
 
     if (!delete_key && !strncmp(macStr, "none", MAX_ADDR_SIZE))
@@ -198,10 +214,12 @@ void NeighSync::onMsg(int nlmsg_type, struct nl_object *obj)
         return;
     }
 
-    /* Ignore neighbor entries with Broadcast Mac - Trigger for directed broadcast */
-    if (!delete_key && (MacAddress(macStr) == MacAddress("ff:ff:ff:ff:ff:ff")))
+    /* Ignore neighbor entries with Broadcast/Null Mac */
+    if (!delete_key
+        && ((lladdr == NULL)
+            || (MacAddress(macStr) == MacAddress("ff:ff:ff:ff:ff:ff"))))
     {
-        SWSS_LOG_INFO("Broadcast Mac received, ignoring for %s", ipStr);
+        SWSS_LOG_INFO("Broadcast/Null Mac received, ignoring for %s", ipStr);
         return;
     }
 


### PR DESCRIPTION
JIRA-JRTC-7979: [neighsync] Ignore neighbor entries on non-router-interface

Change-Id: I403ea67142ac482181c6298ec6c560d361cd205b

JIRA-SONIC-4938: Don't ignore reserved IPv4 LL address

- For BGP unnumber, reserved IPv4 LL (169.254.0.1) will be used as next hop. FRR configure it as permanent neighbor when BGP session is established. We ignore neighbor entry learned on non-router interface currently, this reserved IPv4 LL will not be synced if we don't configure use-link-local-only before this neighbor learnt event.

Change-Id: I21ba7b15ea2437747be95e4ccf234db05fb9601c

JIRA-SONIC-6815: [neighsyncd] Ignore null MAC address neighbor while adding neighbor

By executing the following commands would cause the netlink message bring a NULL MAC neighbor and cause the neighsyncd exception.

The libnl api `nl_addr2str` would output the string `"none"` if the lladdr is `NULL`, and the string is an exception case for the class `MacAddress`. Therefore, this commit add to ignore this condition while the `rtnl_neigh_get_lladdr` can not retrieve the lladdr successfully

```
ip neigh replace 1.2.3.8 lladdr 00:33:55:66:55:66 dev Vlan10 nud noarp
ip neigh replace 1.2.3.8 lladdr 00:33:55:66:55:66 dev Vlan10 nud none
```

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

**Why I did it**

**How I verified it**

**Details if related**
