### PR TITLE
[fpmsyncd] check RTM_DELROUTE when eth0/docker0 has become the only next hop

### DIFF
--- a/fpmsyncd/routesync.cpp
+++ b/fpmsyncd/routesync.cpp
@@ -738,7 +738,7 @@ void RouteSync::onRouteMsg(int nlmsg_type, struct nl_object *obj, char *vrf)
             // In this case since we do not want the route with next hop on eth0/docker0, we return. 
             // But still we need to clear the route from the APPL_DB. Otherwise the APPL_DB and data 
             // path will be left with stale route entry
-            if(alsv.size() == 1)
+            if((nlmsg_type == RTM_DELROUTE) && (alsv.size() == 1))
             {
                 if (!warmRestartInProgress)
                 {


### PR DESCRIPTION
[fpmsyncd] check RTM_DELROUTE when eth0/docker0 has become the only next hop

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->