### PR TITLE
Fix IPv6 link-local address can't work in VRF

### DIFF
--- a/orchagent/vrforch.cpp
+++ b/orchagent/vrforch.cpp
@@ -13,6 +13,7 @@
 #include "vxlanorch.h"
 #include "flowcounterrouteorch.h"
 #include "directory.h"
+#include "routeorch.h"
 
 using namespace std;
 using namespace swss;
@@ -23,6 +24,7 @@ extern sai_object_id_t gSwitchId;
 extern Directory<Orch*>      gDirectory;
 extern PortsOrch*            gPortsOrch;
 extern FlowCounterRouteOrch* gFlowCounterRouteOrch;
+extern RouteOrch*            gRouteOrch;
 
 bool VRFOrch::addOperation(const Request& request)
 {
@@ -104,6 +106,20 @@ bool VRFOrch::addOperation(const Request& request)
             }
         }
 
+        /* Add link-local fe80::/10 CPU route for the VRF. */
+        IpPrefix default_link_local_prefix("fe80::/10");
+        gRouteOrch->addLinkLocalRouteToMe(router_id, default_link_local_prefix);
+        SWSS_LOG_NOTICE("Created link local ipv6 route %s to cpu in VRF %s", default_link_local_prefix.to_string().c_str(), vrf_name.c_str());
+
+        /* All the interfaces have the same MAC address and hence the same
+         * auto-generated link-local ipv6 address with eui64 interface-id.
+         * Hence add a single /128 route entry for the link-local interface
+         * address pointing to the CPU port.
+         */
+        IpPrefix linklocal_prefix = gRouteOrch->getLinkLocalEui64Addr();
+        gRouteOrch->addLinkLocalRouteToMe(router_id, linklocal_prefix);
+        SWSS_LOG_NOTICE("Created link local ipv6 route %s to cpu in VRF %s", linklocal_prefix.to_string().c_str(), vrf_name.c_str());
+
         vrf_table_[vrf_name].vrf_id = router_id;
         vrf_table_[vrf_name].ref_count = 0;
         vrf_id_table_[router_id] = vrf_name;
@@ -169,6 +185,17 @@ bool VRFOrch::delOperation(const Request& request)
         return false;
 
     sai_object_id_t router_id = vrf_table_[vrf_name].vrf_id;
+
+    /* Delete link-local ipv6 address with eui64 /128 CPU route for the VRF. */
+    IpPrefix linklocal_prefix = gRouteOrch->getLinkLocalEui64Addr();
+    gRouteOrch->delLinkLocalRouteToMe(router_id, linklocal_prefix);
+    SWSS_LOG_NOTICE("Deleted link local ipv6 route %s to cpu in VRF %s", linklocal_prefix.to_string().c_str(), vrf_name.c_str());
+
+    /* Delete link-local fe80::/10 CPU route for the VRF. */
+    IpPrefix default_link_local_prefix("fe80::/10");
+    gRouteOrch->delLinkLocalRouteToMe(router_id, default_link_local_prefix);
+    SWSS_LOG_NOTICE("Deleted link local ipv6 route %s to cpu in VRF %s", default_link_local_prefix.to_string().c_str(), vrf_name.c_str());
+
     sai_status_t status = sai_virtual_router_api->remove_virtual_router(router_id);
     if (status != SAI_STATUS_SUCCESS)
     {


### PR DESCRIPTION
**What I did**
Add/Delete IPv6 link-local route to me in VRF when VRF add/delete to trap packet to CPU

**Why I did it**
The IPv6 link-local address can't work on VRF. 
The packet which ip destination is IPv6 link-local address would be dropped.
The root cause is that there is not route for the IPv6 link-local address on VRF

**How to verify it**
Ping the IPv6 link-local address of DUT via the interface which is added in VRF