### PR TITLE
[portsorch] Change setPortPvid failed log level to NOTICE and retry while addLagMember failed with setPortPvid

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -2249,7 +2249,7 @@ bool PortsOrch::setPortPvid(Port &port, sai_uint32_t pvid)
 
     if (port.m_rif_id)
     {
-        SWSS_LOG_ERROR("pvid setting for router interface %s is not allowed", port.m_alias.c_str());
+        SWSS_LOG_NOTICE("pvid setting for router interface %s is not allowed", port.m_alias.c_str());
         return false;
     }
 
@@ -6497,7 +6497,10 @@ bool PortsOrch::addLagMember(Port &lag, Port &port, string member_status)
     sai_uint32_t pvid;
     if (getPortPvid(lag, pvid))
     {
-        setPortPvid (port, pvid);
+        if(!setPortPvid (port, pvid))
+        {
+            return false;
+        }
     }
 
     sai_attribute_t attr;


### PR DESCRIPTION
add retry while addLagMember failed with setPortPvid

To avoid race condition when intfsync/intfmgr disabling ipv6

Let setPortpvid get retry and set the harmless message log level lower

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->
