### PR TITLE
[routeorch] Assign ec default value to maximum number of next hop gro…

### DIFF
--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -33,6 +33,7 @@ extern string gMySwitchType;
 
 /* Default maximum number of next hop groups */
 #define DEFAULT_NUMBER_OF_ECMP_GROUPS   128
+#define EC_DEFAULT_NUMBER_OF_ECMP_GROUPS   32
 #define DEFAULT_MAX_ECMP_GROUP_SIZE     32
 
 RouteOrch::RouteOrch(DBConnector *db, vector<table_name_with_pri_t> &tableNames, SwitchOrch *switchOrch, NeighOrch *neighOrch, IntfsOrch *intfsOrch, VRFOrch *vrfOrch, FgNhgOrch *fgNhgOrch, Srv6Orch *srv6Orch) :
@@ -81,6 +82,13 @@ RouteOrch::RouteOrch(DBConnector *db, vector<table_name_with_pri_t> &tableNames,
         if (platform && strstr(platform, MLNX_PLATFORM_SUBSTRING))
         {
             m_maxNextHopGroupCount /= DEFAULT_MAX_ECMP_GROUP_SIZE;
+        }
+
+        /* For 202411 sai issue, this api get fail but will return success with value 0 */
+        if (attr.value.s32 == 0)
+        {
+            SWSS_LOG_WARN("Number of ECMP groups get from switch attribute is 0. Use ec platform minimal value.");
+            m_maxNextHopGroupCount = EC_DEFAULT_NUMBER_OF_ECMP_GROUPS;
         }
     }
     vector<FieldValueTuple> fvTuple;


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
- In 202411 commuity sai, there is an issue in get_api that get fail but return value 0.

#### How I did it
- Assign a default value when get ecmp groups value is 0.

#### How to verify it
- Run sonic-mgmt test, in AS4630-54TE with t1 topology, test case: test_port_toggle.py

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)




















