### PR TITLE
[orchagent] Do not restore port admin if port admin is configured (#3…

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -4277,7 +4277,7 @@ void PortsOrch::doPortTask(Consumer &consumer)
                 initHostTxReadyState(p);
 
                 // Restore admin status if the port was brought down
-                if (admin_status != p.m_admin_state_up)
+                if (admin_status != p.m_admin_state_up && pCfg.admin_status.is_set == false)
                 {
                     pCfg.admin_status.is_set = true;
                     pCfg.admin_status.value = admin_status;

--- a/tests/test_port.py
+++ b/tests/test_port.py
@@ -305,6 +305,59 @@ class TestPort(object):
         expected_fields = {"SAI_PORT_ATTR_HOST_TX_SIGNAL_ENABLE":"false"}
         adb.wait_for_field_match("ASIC_STATE:SAI_OBJECT_TYPE_PORT", port_oid, expected_fields)
 
+    def test_PortAdminRestore(self, dvs, testlog):
+        appdb = swsscommon.DBConnector(0, dvs.redis_sock, 0)
+        asicdb = swsscommon.DBConnector(1, dvs.redis_sock, 0)
+
+        ptbl = swsscommon.ProducerStateTable(appdb, "PORT_TABLE")
+        atbl = swsscommon.Table(asicdb, "ASIC_STATE:SAI_OBJECT_TYPE_PORT")
+
+        # Initialize Ethernet0 (admin_status, fec) = (up, rs)
+        fvs = swsscommon.FieldValuePairs([("admin_status", "up"),
+                                          ("fec", "rs")])
+        ptbl.set("Ethernet0", fvs)
+
+        time.sleep(1)
+
+        (status, fvs) = atbl.get(dvs.asicdb.portnamemap["Ethernet0"])
+        assert status == True
+
+        for fv in fvs:
+            if fv[0] == "SAI_PORT_ATTR_FEC_MODE":
+                assert fv[1] == "SAI_PORT_FEC_MODE_RS"
+            if fv[0] == "SAI_PORT_ATTR_ADMIN_STATE":
+                assert fv[1] == "true"
+
+        # Verify pCfg.admin_status.is_set false by (fec) = (none)
+        fvs = swsscommon.FieldValuePairs([("fec", "none")])
+        ptbl.set("Ethernet0", fvs)
+
+        time.sleep(1)
+
+        (status, fvs) = atbl.get(dvs.asicdb.portnamemap["Ethernet0"])
+        assert status == True
+
+        for fv in fvs:
+            if fv[0] == "SAI_PORT_ATTR_FEC_MODE":
+                assert fv[1] == "SAI_PORT_FEC_MODE_NONE"
+            if fv[0] == "SAI_PORT_ATTR_ADMIN_STATE":
+                assert fv[1] == "true"
+
+        # Verify pCfg.admin_status.is_set true by (admin_status, fec) = (down, rs)
+        fvs = swsscommon.FieldValuePairs([("admin_status", "down"),
+                                          ("fec", "rs")])
+        ptbl.set("Ethernet0", fvs)
+
+        time.sleep(1)
+
+        (status, fvs) = atbl.get(dvs.asicdb.portnamemap["Ethernet0"])
+        assert status == True
+
+        for fv in fvs:
+            if fv[0] == "SAI_PORT_ATTR_FEC_MODE":
+                assert fv[1] == "SAI_PORT_FEC_MODE_RS"
+            if fv[0] == "SAI_PORT_ATTR_ADMIN_STATE":
+                assert fv[1] == "false"
 
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying


### PR DESCRIPTION
**What I did**
Only restore port admin if port admin is not configured.
**Why I did it**
The pCfg.admin_status might be overridden by prior configurations.
**How I verified it**

**Details if related**
https://github.com/sonic-net/sonic-swss/pull/3447