### PR TITLE
[route] filter out full mask subnet routes from kernel

### DIFF
--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -848,8 +848,8 @@ void RouteOrch::doTask(Consumer& consumer)
                     {
                         it = consumer.m_toSync.erase(it);
                     }
-                    /* fullmask subnet route is same as ip2me route */
-                    else if (ip_prefix.isFullMask() && m_intfsOrch->isPrefixSubnet(ip_prefix, alsv[0]))
+                    /* fullmask subnet route is not allowed */
+                    else if (ip_prefix.isFullMask())
                     {
                         it = consumer.m_toSync.erase(it);
                     }


### PR DESCRIPTION
filter out full mask subnet routes from kernel

#### Why I did it
user can add subnet route using ""ip route add a.b.c.d/xx dev yy"" which directly adding route to kernel.
These routes will be written to chip as subnet route follows the path:Zebra->fpmsyncd->orchagent->syncd
If the route is /32 (/128 for ipv6), it can be deleted by neighbor entry with the same ip address.
In BRCM's SAI, it will carry a flag BCM_L3_HOST_AS_ROUTE to sdk when adding neighbor entry.
This means it will delete the corresponding /32 (/128) route entry if exist.
If the route is deleted silently when adding neighbor entry, it will cause syncd crash when the route want to be deleted from syncd.
We do not allow /32 (/128) subnet route when using config CLI command, so we also filter out these kind of subnet routes.

#### How I did it
N/A

#### How to verify it
N/A"