### PR TITLE
remove filtering of NUD_NOARP state for neighbor entry

### DIFF
--- a/neighsyncd/neighsync.cpp
+++ b/neighsyncd/neighsync.cpp
@@ -150,11 +150,6 @@ void NeighSync::onMsg(int nlmsg_type, struct nl_object *obj)
     key+= ipStr;
 
     int state = rtnl_neigh_get_state(neigh);
-    if (state == NUD_NOARP)
-    {
-        return;
-    }
-
     bool delete_key = false;
     bool use_zero_mac = false;
     if (is_dualtor && (state == NUD_INCOMPLETE || state == NUD_FAILED))


### PR DESCRIPTION
remove filtering of NUD_NOARP state for neighbor entry

#### Why I did it
In EVPN, remote neighbor will write to Linux kernel in NUD_NOARP state.
We need to process this kind of neighbor.

#### How I did it
N/A

#### How to verify it
N/A