### PR TITLE
[neighsync] bug: VXLAN EVPN neighbors not in NEIGH_TABLE (#3478)

### DIFF
--- a/neighsyncd/neighsync.cpp
+++ b/neighsyncd/neighsync.cpp
@@ -14,6 +14,7 @@
 #include "neighsync.h"
 #include "warm_restart.h"
 #include <algorithm>
+#include <linux/neighbour.h>
 
 using namespace std;
 using namespace swss;
@@ -141,18 +142,28 @@ void NeighSync::onMsg(int nlmsg_type, struct nl_object *obj)
     {
         if ((isLinkLocalEnabled(intfName) == false) && (nlmsg_type != RTM_DELNEIGH))
         {
+            SWSS_LOG_INFO("LinkLocal address received, ignoring for %s", ipStr);
             return;
         }
     }
     /* Ignore IPv6 multicast link-local addresses as neighbors */
     if (family == IPV6_NAME && IN6_IS_ADDR_MC_LINKLOCAL(nl_addr_get_binary_addr(rtnl_neigh_get_dst(neigh))))
+    {
+        SWSS_LOG_INFO("Multicast LinkLocal address received, ignoring for %s", ipStr);
         return;
+    }
     key+= ipStr;
 
     int state = rtnl_neigh_get_state(neigh);
     if (state == NUD_NOARP)
     {
-        return;
+        /* For externally learned neighbors, e.g. VXLAN EVPN, we want to keep
+         * these neighbors. */
+        if (!(rtnl_neigh_get_flags(neigh) & NTF_EXT_LEARNED))
+        {
+            SWSS_LOG_INFO("NOARP address received, ignoring for %s", ipStr);
+            return;
+        }
     }
 
     bool delete_key = false;


### PR DESCRIPTION
* [neighsync] VXLAN EVPN neighbors not in NEIGH_TABLE

VXLAN EVPN learned routes are not entered into NEIGH_TABLE as per Issue #3384.

The EVPN VXLAN HLD specifically states this should be populated so it triggers an update to the SAI database:

https://github.com/sonic-net/SONiC/blob/master/doc/vxlan/EVPN/EVPN_VXLAN_HLD.md#438-mac-ip-route-handling

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
N/A
**Why I did it**
N/A
**How I verified it**
N/A
