### PR TITLE
Add missing updateL3VniVlan part in vxlanorch

### DIFF
--- a/orchagent/vxlanorch.cpp
+++ b/orchagent/vxlanorch.cpp
@@ -2002,6 +2002,12 @@ bool VxlanTunnelMapOrch::addOperation(const Request& request)
 
     tunnel_orch->addVlanMappedToVni(vni_id, vlan_id);
 
+    if (0 == vrf_orch->getL3VniVlan(vni_id))
+    {
+        SWSS_LOG_NOTICE("update l3vni %d, vlan %d", vni_id, vlan_id);
+        vrf_orch->updateL3VniVlan(vni_id, vlan_id);
+    }
+
     SWSS_LOG_NOTICE("Vxlan tunnel map entry '%s' for tunnel '%s' was created",
                    tunnel_map_entry_name.c_str(), tunnel_name.c_str());
 


### PR DESCRIPTION
Add missing updateL3VniVlan part in vxlanorch

#### Why I did it
The code exist in original PR but removed in 202012 formal merge
It is needed in MCLAG Active-Active mode

#### How I did it
N/A

#### How to verify it
N/A