### PR TITLE
[aclorch] Correct mask value for MATCH_TUNNEL_VNI

### DIFF
--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -989,7 +989,7 @@ bool AclRule::validateAddMatch(string attr_name, string attr_value)
         else if (attr_name == MATCH_TUNNEL_VNI)
         {
             matchData.data.u32 = to_uint<uint32_t>(attr_value);
-            matchData.mask.u32 = 0xFFFFFFFF;
+            matchData.mask.u32 = 0xFFFFFF;
         }
         else if (attr_name == MATCH_INNER_ETHER_TYPE || attr_name == MATCH_INNER_L4_SRC_PORT ||
             attr_name == MATCH_INNER_L4_DST_PORT)


### PR DESCRIPTION
#### Why I did it
The mask value for MATCH_TUNNEL_VNI was incorrect. It should match the 3-byte (24-bit) tunnel VNI field to ensure proper filtering.

#### How I did it
Updated the mask to correctly cover the 3-byte VNI field.

#### How to verify it
N/A