### PR TITLE
[portsorch] Check FDB count is cleared before removing bridge port

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -4615,22 +4615,23 @@ void PortsOrch::doVlanMemberTask(Consumer &consumer)
         {
             if (vlan.m_members.find(port_alias) != vlan.m_members.end())
             {
-                if (removeVlanMember(vlan, port))
-                {
-                    if (m_portVlanMember[port.m_alias].empty())
-                    {
-                        removeBridgePort(port);
-                    }
-                    it = consumer.m_toSync.erase(it);
-                }
-                else
+                if (!removeVlanMember(vlan, port))
                 {
                     it++;
+                    continue;
                 }
             }
-            else
-                /* Cannot locate the VLAN */
-                it = consumer.m_toSync.erase(it);
+
+            if (m_portVlanMember[port.m_alias].empty())
+            {
+                if (!removeBridgePort(port))
+                {
+                    it++;
+                    continue;
+                }
+            }
+
+            it = consumer.m_toSync.erase(it);
         }
         else
         {
@@ -5707,6 +5708,13 @@ bool PortsOrch::removeBridgePort(Port &port)
     //Flush the FDB entires corresponding to the port
     gFdbOrch->flushFDBEntries(port.m_bridge_port_id, SAI_NULL_OBJECT_ID);
     SWSS_LOG_INFO("Flush FDB entries for port %s", port.m_alias.c_str());
+
+    if (port.m_fdb_count != 0)
+    {
+        // SWSS_LOG_NOTICE("Still has %d FDB entries, couldn't remove bridge port %s",
+        //         port.m_fdb_count, port.m_alias.c_str());
+        return false;
+    }
 
     /* Remove bridge port */
     status = sai_bridge_api->remove_bridge_port(port.m_bridge_port_id);


### PR DESCRIPTION
#### Why I did it  
The bridge port should not be removed if there are associated FDB entries, meaning the FDB count is greater than 0. 
Removing the bridge port before clearing the FDB entries leads to FDB update failures.

#### How I did it  
Ensured that the FDB count is checked and cleared before allowing the bridge port to be removed.

The following steps is able to reproduce the issue.
1. Remove a VLAN member with associated FDB entries. 
2. The bridge port would be removed without checking the FDB count is cleared.
3. Receive FDB event for the bridge port, then failed to update the FDB.
4. Remove VLAN is failed because the FDB count of the VLAN is not cleared
5. Keep retrying to remove the VLAN

#### How to verify it  
1. Remove a VLAN member with associated FDB entries.
2. Verify that the bridge port is not removed if the FDB count is greater than 0.
3. Ensure FDB entries are updated correctly and VLAN removal proceeds without error.
4. Check that retries are not triggered unnecessarily for VLAN removal.
