### PR TITLE
Enhance orchagent to prevent crash if SAI_NEIGHBOR call return error

### DIFF
--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -25,6 +25,11 @@ extern BfdOrch *gBfdOrch;
 
 const int neighorch_pri = 30;
 
+map<sai_status_t, string> sai_error_reason =
+{
+    {SAI_STATUS_TABLE_FULL, "table full"}
+};
+
 NeighOrch::NeighOrch(DBConnector *appDb, string tableName, IntfsOrch *intfsOrch, FdbOrch *fdbOrch, PortsOrch *portsOrch, DBConnector *chassisAppDb) :
         Orch(appDb, tableName, neighorch_pri),
         m_intfsOrch(intfsOrch),
@@ -37,10 +42,13 @@ NeighOrch::NeighOrch(DBConnector *appDb, string tableName, IntfsOrch *intfsOrch,
     m_fdbOrch->attach(this);
 
     // Some UTs instantiate NeighOrch but gBfdOrch is null, it is not null in orchagent
-    if (gBfdOrch) 
-    {  
+    if (gBfdOrch)
+    {
         gBfdOrch->attach(this);
     }
+
+    unique_ptr<DBConnector> stateDb;
+    stateDb = make_unique<DBConnector>("STATE_DB", 0);
 
     if(gMySwitchType == "voq")
     {
@@ -50,10 +58,10 @@ NeighOrch::NeighOrch(DBConnector *appDb, string tableName, IntfsOrch *intfsOrch,
         m_tableVoqSystemNeighTable = unique_ptr<Table>(new Table(chassisAppDb, CHASSIS_APP_SYSTEM_NEIGH_TABLE_NAME));
 
         //STATE DB connection for setting state of the remote neighbor SAI programming
-        unique_ptr<DBConnector> stateDb;
-        stateDb = make_unique<DBConnector>("STATE_DB", 0);
         m_stateSystemNeighTable = unique_ptr<Table>(new Table(stateDb.get(), STATE_SYSTEM_NEIGH_TABLE_NAME));
     }
+
+    m_stateNeighInvalidTable = unique_ptr<Table>(new Table(stateDb.get(), STATE_NEIGH_INVALID_TABLE_NAME));
 }
 
 NeighOrch::~NeighOrch()
@@ -882,9 +890,18 @@ void NeighOrch::doTask(Consumer &consumer)
                     it++;
                 }
             }
-            else
+            else {
+                // Remove neighbor from invalid entries if it matches
+                string state_key = alias + state_db_key_delimiter + ip_address.to_string();
+                vector<FieldValueTuple> invalid_entries;
+                if (m_stateNeighInvalidTable->get(state_key, invalid_entries)) {
+                    m_stateNeighInvalidTable->del(state_key);
+                    SWSS_LOG_NOTICE("Removed invalid neighbor %s on %s", ip_address.to_string().c_str(), alias.c_str());
+                }
+
                 /* Cannot locate the neighbor */
                 it = consumer.m_toSync.erase(it);
+            }
         }
         else
         {
@@ -948,25 +965,27 @@ bool NeighOrch::addNeighbor(const NeighborEntry &neighborEntry, const MacAddress
     {
         status = sai_neighbor_api->create_neighbor_entry(&neighbor_entry,
                                    (uint32_t)neighbor_attrs.size(), neighbor_attrs.data());
-        if (status != SAI_STATUS_SUCCESS)
+        task_process_status handle_status = handleSaiCreateStatus(SAI_API_NEIGHBOR, status);
+        if (handle_status != task_success)
         {
-            if (status == SAI_STATUS_ITEM_ALREADY_EXISTS)
-            {
-                SWSS_LOG_ERROR("Entry exists: neighbor %s on %s, rv:%d",
-                           macAddress.to_string().c_str(), alias.c_str(), status);
-                /* Returning True so as to skip retry */
-                return true;
+            SWSS_LOG_ERROR("Failed to create neighbor %s on %s, rv:%d", macAddress.to_string().c_str(), alias.c_str(), status);
+            if (handle_status == task_invalid_entry) {
+                string state_key = alias + state_db_key_delimiter + ip_address.to_string();
+                vector<FieldValueTuple> fvVector;
+                FieldValueTuple mac("neigh", macAddress.to_string());
+                fvVector.push_back(mac);
+
+                FieldValueTuple family("family", ip_address.isV4() ? "IPv4" : "IPv6");
+                fvVector.push_back(family);
+
+                FieldValueTuple reason("reason", sai_error_reason.count(status) ? sai_error_reason[status]: "unknown");
+                fvVector.push_back(reason);
+                m_stateNeighInvalidTable->set(state_key, fvVector);
+            } else if (handle_status == task_ignore) {
+                SWSS_LOG_ERROR("Ignore to create neighbor %s on %s, rv:%d", macAddress.to_string().c_str(), alias.c_str(), status);
             }
-            else
-            {
-                SWSS_LOG_ERROR("Failed to create neighbor %s on %s, rv:%d",
-                           macAddress.to_string().c_str(), alias.c_str(), status);
-                task_process_status handle_status = handleSaiCreateStatus(SAI_API_NEIGHBOR, status);
-                if (handle_status != task_success)
-                {
-                    return parseHandleSaiStatusFailure(handle_status);
-                }
-            }
+
+            return parseHandleSaiStatusFailure(handle_status);
         }
         SWSS_LOG_NOTICE("Created neighbor ip %s, %s on %s", ip_address.to_string().c_str(),
                 macAddress.to_string().c_str(), alias.c_str());
@@ -1581,18 +1600,27 @@ bool NeighOrch::addInbandNeighbor(string alias, IpAddress ip_address)
     neighbor_attrs.push_back(attr);
 
     status = sai_neighbor_api->create_neighbor_entry(&neighbor_entry, static_cast<uint32_t>(neighbor_attrs.size()), neighbor_attrs.data());
-    if (status != SAI_STATUS_SUCCESS)
+    task_process_status handle_status = handleSaiCreateStatus(SAI_API_NEIGHBOR, status);
+    if (handle_status != task_success)
     {
-        if (status == SAI_STATUS_ITEM_ALREADY_EXISTS)
-        {
-            SWSS_LOG_ERROR("Entry exists: neighbor %s on %s, rv:%d", inband_mac.to_string().c_str(), alias.c_str(), status);
-            return true;
+        SWSS_LOG_ERROR("Failed to create neighbor %s on %s, rv:%d", inband_mac.to_string().c_str(), alias.c_str(), status);
+        if (handle_status == task_invalid_entry) {
+            string state_key = alias + state_db_key_delimiter + ip_address.to_string();
+            vector<FieldValueTuple> fvVector;
+            FieldValueTuple mac("neigh", inband_mac.to_string());
+            fvVector.push_back(mac);
+
+            FieldValueTuple family("family", ip_address.isV4() ? "IPv4" : "IPv6");
+            fvVector.push_back(family);
+
+            FieldValueTuple reason("reason", sai_error_reason.count(status) ? sai_error_reason[status]: "unknown");
+            fvVector.push_back(reason);
+            m_stateNeighInvalidTable->set(state_key, fvVector);
+        } else if (handle_status == task_ignore) {
+            SWSS_LOG_ERROR("Ignore to create neighbor %s on %s, rv:%d", inband_mac.to_string().c_str(), alias.c_str(), status);
         }
-        else
-        {
-            SWSS_LOG_ERROR("Failed to create neighbor %s on %s, rv:%d", inband_mac.to_string().c_str(), alias.c_str(), status);
-            return false;
-        }
+
+        return parseHandleSaiStatusFailure(handle_status);
     }
 
     SWSS_LOG_NOTICE("Created inband neighbor %s on %s", inband_mac.to_string().c_str(), alias.c_str());

--- a/orchagent/neighorch.h
+++ b/orchagent/neighorch.h
@@ -108,6 +108,7 @@ private:
 
     unique_ptr<Table> m_tableVoqSystemNeighTable;
     unique_ptr<Table> m_stateSystemNeighTable;
+    unique_ptr<Table> m_stateNeighInvalidTable;
     bool getSystemPortNeighEncapIndex(string &alias, IpAddress &ip, uint32_t &encap_index);
     bool addVoqEncapIndex(string &alias, IpAddress &ip, vector<sai_attribute_t> &neighbor_attrs);
     void voqSyncAddNeigh(string &alias, IpAddress &ip_address, const MacAddress &mac, sai_neighbor_entry_t &neighbor_entry);

--- a/orchagent/saihelper.cpp
+++ b/orchagent/saihelper.cpp
@@ -557,7 +557,6 @@ task_process_status handleSaiCreateStatus(sai_api_t api, sai_status_t status, vo
                     break;
             }
             break;
-        case SAI_API_NEIGHBOR:
         case SAI_API_NEXT_HOP:
         case SAI_API_NEXT_HOP_GROUP:
             switch(status)
@@ -569,6 +568,30 @@ task_process_status handleSaiCreateStatus(sai_api_t api, sai_status_t status, vo
                     return task_success;
                 case SAI_STATUS_TABLE_FULL:
                     return task_need_retry;
+                default:
+                    SWSS_LOG_ERROR("Encountered failure in create operation, exiting orchagent, SAI API: %s, status: %s",
+                                sai_serialize_api(api).c_str(), sai_serialize_status(status).c_str());
+                    handleSaiFailure(true);
+                    break;
+            }
+            break;
+        case SAI_API_NEIGHBOR:
+            switch (status)
+            {
+                case SAI_STATUS_SUCCESS:
+                    return task_success;
+                case SAI_STATUS_ITEM_ALREADY_EXISTS:
+                    /*
+                     *  In neighbor creation, the NEIGHBOR SAI creation would report the status of SAI_STATUS_ITEM_ALREADY_EXISTS,
+                     *  and orchagent should ignore the error and treat it as entry was explicitly created.
+                     */
+                    return task_ignore;
+                case SAI_STATUS_TABLE_FULL:
+                    /*
+                     * Neighbor entry may encounter hash collision and return table full, this will be handled by orchagent to recored the invalid entry.
+                     * We don't abort it in order to prevent the system crash.
+                     */
+                    return task_invalid_entry;
                 default:
                     SWSS_LOG_ERROR("Encountered failure in create operation, exiting orchagent, SAI API: %s, status: %s",
                                 sai_serialize_api(api).c_str(), sai_serialize_status(status).c_str());


### PR DESCRIPTION
* Refactor to handle SAI create_neighbor_entry return value. 
  Record the failed SAI api call neighbor to NEIGH_INVALID_TABLE in STATE_DB,
  and remove it from m_toSync to prevent retrying.