### PR TITLE
[swss] Fix for STATE_DB update for removed port during breakout (#3474)

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -1509,6 +1509,8 @@ bool PortsOrch::setPortAdminStatus(Port &port, bool state)
 void PortsOrch::setHostTxReady(sai_object_id_t portId, const std::string &status)
 {
     Port p;
+    vector<FieldValueTuple> tuples;
+    bool exist;
 
     if (!getPort(portId, p))
     {
@@ -1516,8 +1518,13 @@ void PortsOrch::setHostTxReady(sai_object_id_t portId, const std::string &status
         return;
     }
 
-    SWSS_LOG_NOTICE("Setting host_tx_ready status = %s, alias = %s, port_id = 0x%" PRIx64, status.c_str(), p.m_alias.c_str(), portId);
-    m_portStateTable.hset(p.m_alias, "host_tx_ready", status);
+    /* If the port is revmoed, don't need to update StateDB*/
+    exist = m_portStateTable.get(p.m_alias, tuples);
+    if (exist)
+    {
+        SWSS_LOG_NOTICE("Setting host_tx_ready status = %s, alias = %s, port_id = 0x%" PRIx64, status.c_str(), p.m_alias.c_str(), portId);
+        m_portStateTable.hset(p.m_alias, "host_tx_ready", status);
+    }
 }
 
 bool PortsOrch::getPortAdminStatus(sai_object_id_t id, bool &up)


### PR DESCRIPTION
Fix for STATE_DB update for removed port during breakout. The removed interface still exits in STATE_DB PORT_TABLE Breakout port from 4x100G to 1x100G. It still have host_tx_ready for the removed interface in STATE_DB.

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

**Why I did it**

**How I verified it**

**Details if related**
