### PR TITLE
[vxlan] Tunnel port don't need to flush fdb.

### DIFF
--- a/orchagent/fdborch.cpp
+++ b/orchagent/fdborch.cpp
@@ -1243,8 +1243,11 @@ void FdbOrch::updateVlanMember(const VlanMemberUpdate& update)
     {
         swss::Port vlan = update.vlan;
         swss::Port port = update.member;
-        flushFDBEntries(port.m_bridge_port_id, vlan.m_vlan_info.vlan_oid);
-        notifyObserversFDBFlush(port, vlan.m_vlan_info.vlan_oid);
+        if(port.m_type != Port::TUNNEL)
+        {
+            flushFDBEntries(port.m_bridge_port_id, vlan.m_vlan_info.vlan_oid);
+            notifyObserversFDBFlush(port, vlan.m_vlan_info.vlan_oid);
+        }
         return;
     }
 


### PR DESCRIPTION
Tunnel port don't need to flush fdb.

#### Why I did it
N/A

#### How I did it
N/A

#### How to verify it
N/A