### PR TITLE
[intf] add router interface should remove vlan/lag member first.

### DIFF
--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -1160,6 +1160,18 @@ bool IntfsOrch::addRouterIntfs(sai_object_id_t vrf_id, Port &port, string loopba
         return true;
     }
 
+    if (port.m_lag_member_id)
+    {
+        SWSS_LOG_WARN("It's portchannel member %s", port.m_alias.c_str());
+        return false;
+    }
+
+    if (!gPortsOrch->isPortVlanMembersEmpty(port))
+    {
+        SWSS_LOG_WARN("It's vlan member %s", port.m_alias.c_str());
+        return false;
+    }
+
     if ((port.m_type == Port::PHY || port.m_type == Port::LAG)
         && port.m_bridge_port_id != SAI_NULL_OBJECT_ID)
     {

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -6025,6 +6025,11 @@ bool PortsOrch::getPortVlanMembers(Port &port, vlan_members_t &vlan_members)
     return true;
 }
 
+bool PortsOrch::isPortVlanMembersEmpty(Port &port)
+{
+    return m_portVlanMember[port.m_alias].empty();
+}
+
 bool PortsOrch::addVlanFloodGroups(Port &vlan, Port &port, string end_point_ip)
 {
     SWSS_LOG_ENTER();

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -217,6 +217,7 @@ public:
     bool isInbandPort(const string &alias);
     bool setVoqInbandIntf(string &alias, string &type);
     bool getPortVlanMembers(Port &port, vlan_members_t &vlan_members);
+    bool isPortVlanMembersEmpty(Port &port);
 
     bool getRecircPort(Port &p, Port::Role role);
 


### PR DESCRIPTION
#### Why I did it
N/A

#### How I did it
add router interface should remove vlan/lag member first.
implement PortsOrch::isPortVlanMembersEmpty to check the private member m_portVlanMember of class PortsOrch

#### How to verify it
N/A