### PR TITLE
Ensure VTEP is set in VXLAN_TUNNEL_TABLE before setting in VXLAN_EVPN_NVO_TABLE

### DIFF
--- a/cfgmgr/vxlanmgr.cpp
+++ b/cfgmgr/vxlanmgr.cpp
@@ -174,6 +174,7 @@ static int cmdDetachVxlanIfFromVnet(const swss::VxlanMgr::VxlanInfo & info, std:
 VxlanMgr::VxlanMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, const vector<std::string> &tables) :
         m_app_db(appDb),
         Orch(cfgDb, tables),
+        m_appVxlanTunnelTableProducer(appDb, APP_VXLAN_TUNNEL_TABLE_NAME),
         m_appVxlanTunnelTable(appDb, APP_VXLAN_TUNNEL_TABLE_NAME),
         m_appVxlanTunnelMapTable(appDb, APP_VXLAN_TUNNEL_MAP_TABLE_NAME),
         m_appSwitchTable(appDb, APP_SWITCH_TABLE_NAME),
@@ -420,7 +421,7 @@ bool VxlanMgr::doVxlanTunnelCreateTask(const KeyOpFieldsValuesTuple & t)
         }
     }
 
-    m_appVxlanTunnelTable.set(vxlanTunnelName, kfvFieldsValues(t));
+    m_appVxlanTunnelTableProducer.set(vxlanTunnelName, kfvFieldsValues(t));
     m_vxlanTunnelCache[vxlanTunnelName] = tuncache;
 
     SWSS_LOG_NOTICE("Create vxlan tunnel %s", vxlanTunnelName.c_str());
@@ -451,7 +452,7 @@ bool VxlanMgr::doVxlanTunnelDeleteTask(const KeyOpFieldsValuesTuple & t)
 
     if (isTunnelActive(vxlanTunnelName))
     {
-        m_appVxlanTunnelTable.del(vxlanTunnelName);
+        m_appVxlanTunnelTableProducer.del(vxlanTunnelName);
     }
 
     auto it1 = m_vxlanTunnelCache.find(vxlanTunnelName);
@@ -679,6 +680,12 @@ bool VxlanMgr::doVxlanEvpnNvoCreateTask(const KeyOpFieldsValuesTuple & t)
         if (!isTunnelActive(value))
         {
             SWSS_LOG_ERROR("NVO %s creation failed. VTEP not present",EvpnNvoName.c_str());
+            return false;
+        }
+        std::vector<FieldValueTuple> fv;
+        if (!m_appVxlanTunnelTable.get(value, fv))
+        {
+            SWSS_LOG_WARN("NVO %s creation delayed. VTEP %s not found", EvpnNvoName.c_str(), value.c_str());
             return false;
         }
         if (field == SOURCE_VTEP)

--- a/cfgmgr/vxlanmgr.h
+++ b/cfgmgr/vxlanmgr.h
@@ -91,8 +91,8 @@ private:
 
     void clearAllVxlanDevices();
 
-    ProducerStateTable m_appVxlanTunnelTable,m_appVxlanTunnelMapTable,m_appEvpnNvoTable;
-    Table m_cfgVxlanTunnelTable,m_cfgVnetTable,m_stateVrfTable,m_stateVxlanTable, m_appSwitchTable;
+    ProducerStateTable m_appVxlanTunnelTableProducer, m_appVxlanTunnelMapTable,m_appEvpnNvoTable;
+    Table m_cfgVxlanTunnelTable,m_cfgVnetTable,m_stateVrfTable,m_stateVxlanTable, m_appSwitchTable, m_appVxlanTunnelTable;
     Table m_stateVlanTable, m_stateNeighSuppressVlanTable, m_stateVxlanTunnelTable;
 
     /*


### PR DESCRIPTION
**What I did**
Fixes a race condition where VXLAN_EVPN_NVO_TABLE could be set before the corresponding VTEP entry exists in VXLAN_TUNNEL_TABLE, leading to a "map::at" logic error in orchagent
**Why I did it**
error log
`Jan 24 00:10:22.340281 as9736-64d-3 WARNING swss#orchagent: :- addOperation: Vxlan tunnel 'vtep' doesn't exist`
`Jan 24 00:10:22.342460 as9736-64d-3 NOTICE syncd#syncd: [none] _brcm_sai_update_vsi_profile:3427 VSI Type 2 is already cleared in vlan 1000`
`Jan 24 00:10:22.370028 as9736-64d-3 WARNING swss#orchagent: message repeated 2 times: [ :- addOperation: Vxlan tunnel 'vtep' doesn't exist]`
`Jan 24 00:10:22.370028 as9736-64d-3 ERR swss#orchagent: :- doTask: Logic error: map::at`
`Jan 24 00:10:22.370028 as9736-64d-3 WARNING swss#orchagent: :- addOperation: Vxlan tunnel 'vtep' doesn't exist`
`Jan 24 00:10:22.371155 as9736-64d-3 NOTICE swss#orchagent: :- addOperation: Vxlan tunnel 'vtep' was added`

swss.rec
`/var/log/swss/swss.rec.14.gz:2025-02-04.10:41:22.547674|VXLAN_EVPN_NVO_TABLE:evpnnvo1|SET|source_vtep:vtep`
`/var/log/swss/swss.rec.14.gz:2025-02-04.10:41:22.562233|VXLAN_TUNNEL_TABLE:vtep|SET|src_ip:10.1.0.32`
**How I verified it**
N/A
**Details if related**
