### PR TITLE
Improve multiple subport-related features

### DIFF
--- a/cfgmgr/Makefile.am
+++ b/cfgmgr/Makefile.am
@@ -31,7 +31,7 @@ COMMON_ORCH_SOURCE = $(top_srcdir)/orchagent/orch.cpp \
 				$(top_srcdir)/orchagent/response_publisher.cpp \
 				$(top_srcdir)/lib/recorder.cpp
 
-vlanmgrd_SOURCES = vlanmgrd.cpp vlanmgr.cpp $(COMMON_ORCH_SOURCE) shellcmd.h
+vlanmgrd_SOURCES = vlanmgrd.cpp vlanmgr.cpp $(COMMON_ORCH_SOURCE) shellcmd.h $(top_srcdir)/lib/subintf.cpp
 vlanmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(CFLAGS_ASAN)
 vlanmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(CFLAGS_ASAN)
 vlanmgrd_LDADD = $(LDFLAGS_ASAN) $(COMMON_LIBS) $(SAIMETA_LIBS)

--- a/cfgmgr/intfmgr.cpp
+++ b/cfgmgr/intfmgr.cpp
@@ -40,7 +40,8 @@ IntfMgr::IntfMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, c
         m_stateVrfTable(stateDb, STATE_VRF_TABLE_NAME),
         m_stateIntfTable(stateDb, STATE_INTERFACE_TABLE_NAME),
         m_appIntfTableProducer(appDb, APP_INTF_TABLE_NAME),
-        m_neighTable(appDb, APP_NEIGH_TABLE_NAME)
+        m_neighTable(appDb, APP_NEIGH_TABLE_NAME),
+        m_cfgVlanTable(cfgDb, CFG_VLAN_TABLE_NAME)
 {
     auto subscriberStateTable = new swss::SubscriberStateTable(stateDb,
             STATE_PORT_TABLE_NAME, TableConsumable::DEFAULT_POP_BATCH_SIZE, 100);
@@ -492,6 +493,8 @@ std::string IntfMgr::setHostSubIntfAdminStatus(const string &alias, const string
     stringstream cmd;
     string res, cmd_str;
 
+    SWSS_LOG_INFO("subintf %s admin_status: %s, parent_admin_status %s", alias.c_str(), admin_status.c_str(), parent_admin_status.c_str());
+
     if (parent_admin_status == "up" || admin_status == "down")
     {
         SWSS_LOG_INFO("subintf %s admin_status: %s", alias.c_str(), admin_status.c_str());
@@ -741,13 +744,10 @@ bool IntfMgr::doIntfGeneralTask(const vector<string>& keys,
         }
         parentAlias = subIf.parentIntf();
         int subIntfId = subIf.subIntfIdx();
-        /*If long name format, subinterface Id is vlanid */
-        if (!subIf.isShortName())
-        {
-            vlanId = std::to_string(subIntfId);
-            FieldValueTuple vlanTuple("vlan", vlanId);
-            data.push_back(vlanTuple);
-        }
+        /*No matter long or short name format, subinterface Id is vlanid */
+        vlanId = std::to_string(subIntfId);
+        FieldValueTuple vlanTuple("vlan", vlanId);
+        data.push_back(vlanTuple);
     }
     bool is_lo = !alias.compare(0, strlen(LOOPBACK_PREFIX), LOOPBACK_PREFIX);
     string mac = "";
@@ -810,6 +810,18 @@ bool IntfMgr::doIntfGeneralTask(const vector<string>& keys,
 
     if (op == SET_COMMAND)
     {
+        string platform = getenv("platform") ? getenv("platform") : "";
+        if (platform == BRCM_PLATFORM_SUBSTRING && !parentAlias.empty())
+        {
+            vector<FieldValueTuple> temp;
+            string vlan_name = VLAN_PREFIX + vlanId;
+            if (m_cfgVlanTable.get(vlan_name, temp))
+            {
+                SWSS_LOG_ERROR("subport %s invaild config: vlan config already", alias.c_str());
+                return true;
+            }
+        }
+
         if (!isIntfStateOk(parentAlias.empty() ? alias : parentAlias))
         {
             SWSS_LOG_DEBUG("Interface is not ready, skipping %s", alias.c_str());
@@ -1014,6 +1026,13 @@ bool IntfMgr::doIntfGeneralTask(const vector<string>& keys,
     }
     else if (op == DEL_COMMAND)
     {
+        vector<FieldValueTuple> temp;
+        if (!m_stateIntfTable.get(alias, temp))
+        {
+            SWSS_LOG_INFO("skip: invaild config protection");
+            return true;
+        }
+
         /* make sure all ip addresses associated with interface are removed, otherwise these ip address would
            be set with global vrf and it may cause ip address conflict. */
         if (getIntfIpCount(alias))

--- a/cfgmgr/intfmgr.h
+++ b/cfgmgr/intfmgr.h
@@ -34,7 +34,7 @@ public:
 
 private:
     ProducerStateTable m_appIntfTableProducer;
-    Table m_cfgIntfTable, m_cfgVlanIntfTable, m_cfgLagIntfTable, m_cfgLoopbackIntfTable;
+    Table m_cfgIntfTable, m_cfgVlanIntfTable, m_cfgLagIntfTable, m_cfgLoopbackIntfTable, m_cfgVlanTable;
     Table m_statePortTable, m_stateLagTable, m_stateVlanTable, m_stateVrfTable, m_stateIntfTable;
     Table m_neighTable;
 

--- a/cfgmgr/vlanmgr.cpp
+++ b/cfgmgr/vlanmgr.cpp
@@ -8,6 +8,7 @@
 #include "shellcmd.h"
 #include "warm_restart.h"
 #include <swss/redisutility.h>
+#include "subintf.h"
 
 using namespace std;
 using namespace swss;
@@ -31,6 +32,7 @@ VlanMgr::VlanMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, c
         m_stateVlanMemberTable(stateDb, STATE_VLAN_MEMBER_TABLE_NAME),
         m_appVlanTableProducer(appDb, APP_VLAN_TABLE_NAME),
         m_appVlanMemberTableProducer(appDb, APP_VLAN_MEMBER_TABLE_NAME),
+        m_cfgSubInterfaceTable(cfgDb, CFG_VLAN_SUB_INTF_TABLE_NAME),
         replayDone(false)
 {
     SWSS_LOG_ENTER();
@@ -287,6 +289,24 @@ bool VlanMgr::isVlanMacOk()
 {
     return !!gMacAddress;
 }
+bool VlanMgr::isSubportConfigVlan(const int vlan_id)
+{
+    std::vector<std::string> keys;
+    m_cfgSubInterfaceTable.getKeys(keys);
+    for (const auto& tmp_key : keys)
+    {
+        if (tmp_key.find(VLAN_SUB_INTERFACE_SEPARATOR) == string::npos)
+        {
+            continue;
+        }
+        subIntf subIf(tmp_key);
+        if (vlan_id && vlan_id == subIf.subIntfIdx())
+        {
+            return true;
+        }
+    }
+    return false;
+}
 
 void VlanMgr::doVlanTask(Consumer &consumer)
 {
@@ -335,6 +355,13 @@ void VlanMgr::doVlanTask(Consumer &consumer)
             vector<FieldValueTuple> fvVector;
             string members;
 
+            string platform = getenv("platform") ? getenv("platform") : "";
+            if (platform == BRCM_PLATFORM_SUBSTRING && isSubportConfigVlan(vlan_id))
+            {
+                it = consumer.m_toSync.erase(it);
+                SWSS_LOG_ERROR("%s invaild config: subport config the vlan already", key.c_str());
+                continue;
+            }
             /*
              * If state is already set for this vlan, but it doesn't exist in m_vlans set,
              * just add it to m_vlans set and remove the request to skip disrupting Linux vlan.

--- a/cfgmgr/vlanmgr.h
+++ b/cfgmgr/vlanmgr.h
@@ -20,13 +20,13 @@ public:
 private:
     ProducerStateTable m_appVlanTableProducer, m_appVlanMemberTableProducer;
     Table m_cfgVlanTable, m_cfgVlanMemberTable;
-    Table m_statePortTable, m_stateLagTable;
+    Table m_statePortTable, m_stateLagTable, m_cfgSubInterfaceTable;
     Table m_stateVlanTable, m_stateVlanMemberTable;
     std::set<std::string> m_vlans;
     std::set<std::string> m_vlanReplay;
     std::set<std::string> m_vlanMemberReplay;
     bool replayDone;
-    
+
     void doTask(Consumer &consumer);
     void doVlanTask(Consumer &consumer);
     void doVlanMemberTask(Consumer &consumer);
@@ -43,6 +43,7 @@ private:
     bool isVlanStateOk(const std::string &alias);
     bool isVlanMacOk();
     bool isVlanMemberStateOk(const std::string &vlanMemberKey);
+    bool isSubportConfigVlan(const int vlan_id);
 };
 
 }

--- a/neighsyncd/neighsync.cpp
+++ b/neighsyncd/neighsync.cpp
@@ -20,6 +20,8 @@ using namespace swss;
 
 #define VLAN_SUB_INTERFACE_SEPARATOR   "."
 #define RESERVED_IPV4_LL    "169.254.0.1"
+#define SHORT_NAME_LAG_PREFIX "Po"
+#define SHORT_NAME_ETH_PREFIX "Eth"
 
 NeighSync::NeighSync(RedisPipeline *pipelineAppDB, DBConnector *stateDb, DBConnector *cfgDb) :
     m_neighTable(pipelineAppDB, APP_NEIGH_TABLE_NAME),
@@ -61,13 +63,15 @@ bool NeighSync::isNeighRestoreDone()
 
 Table *NeighSync::getInterfaceTable(const std::string &intfName)
 {
-    if (intfName.find(FRONT_PANEL_PORT_PREFIX) != string::npos)
+    if (intfName.find(FRONT_PANEL_PORT_PREFIX) != string::npos ||
+	intfName.find(SHORT_NAME_ETH_PREFIX) != string::npos)
     {
         if (intfName.find(VLAN_SUB_INTERFACE_SEPARATOR) != string::npos)
             return &m_cfgSubInterfaceTable;
         return &m_cfgInterfaceTable;
     }
-    else if (intfName.find(PORTCHANNEL_PREFIX) != string::npos)
+    else if (intfName.find(PORTCHANNEL_PREFIX) != string::npos ||
+             intfName.find(SHORT_NAME_LAG_PREFIX) != string::npos)
     {
         if (intfName.find(VLAN_SUB_INTERFACE_SEPARATOR) != string::npos)
             return &m_cfgSubInterfaceTable;
@@ -124,6 +128,14 @@ void NeighSync::onMsg(int nlmsg_type, struct nl_object *obj)
     key+= LinkCache::getInstance().ifindexToName(rtnl_neigh_get_ifindex(neigh));
     intfName = key;
     key+= ":";
+
+    // only process Vlan/Ethernet/PortChannel interface, other types are skipped.
+    if ((intfName.find(VLAN_PREFIX) == string::npos) && (intfName.find(FRONT_PANEL_PORT_PREFIX) == string::npos) && (intfName.find(PORTCHANNEL_PREFIX) == string::npos)
+       && (intfName.find(SHORT_NAME_LAG_PREFIX) == string::npos) && (intfName.find(SHORT_NAME_ETH_PREFIX) == string::npos))
+    {
+        SWSS_LOG_INFO("Skip process interface %s", intfName.c_str());
+        return;
+    }
 
     nl_addr2str(rtnl_neigh_get_dst(neigh), ipStr, MAX_ADDR_SIZE);
 

--- a/tlm_teamd/teamdctl_mgr.cpp
+++ b/tlm_teamd/teamdctl_mgr.cpp
@@ -60,6 +60,12 @@ bool TeamdCtlMgr::has_key(const std::string & lag_name) const
 ///
 bool TeamdCtlMgr::add_lag(const std::string & lag_name)
 {
+    if (lag_name.find(".") != std::string::npos)
+    {
+        SWSS_LOG_INFO("lag_name %s is subport interface, so ignore it.", lag_name.c_str());
+        return true;
+    }
+
     if (has_key(lag_name))
     {
         SWSS_LOG_DEBUG("The LAG '%s' was already added. Skip adding it.", lag_name.c_str());
@@ -121,6 +127,12 @@ bool TeamdCtlMgr::try_add_lag(const std::string & lag_name)
 ///
 bool TeamdCtlMgr::remove_lag(const std::string & lag_name)
 {
+    if (lag_name.find(".") != std::string::npos)
+    {
+        SWSS_LOG_INFO("lag_name %s is subport interface, so ignore it.", lag_name.c_str());
+        return true;
+    }
+
     if (has_key(lag_name))
     {
         auto tdc = m_handlers[lag_name];


### PR DESCRIPTION
- [neighsyncd] neighbor from kernel can be processed if its inerface is short name subport
- [intfmgr] No matter long or short name subport, subinterface ID is VLAN ID
- [vlanmgr] Implement exclusive check for VLAN id and subinterface creation
- [tlm_teamd] tlm_teamd should ignore interface which is subport