### PR TITLE
[WRED] Support the ECN-marked attribute for separate WRED and ECN configurations.

### DIFF
--- a/orchagent/qosorch.cpp
+++ b/orchagent/qosorch.cpp
@@ -753,6 +753,60 @@ bool WredMapHandler::convertFieldValuesToAttributes(KeyOpFieldsValuesTuple &tupl
             attr.value.s32 = ecn;
             attribs.push_back(attr);
         }
+        else if (fvField(*i) == ecn_yellow_max_threshold_field_name)
+        {
+            attr.id = SAI_WRED_ATTR_ECN_YELLOW_MAX_THRESHOLD;
+            attr.value.s32 = stoi(fvValue(*i));
+            attribs.push_back(attr);
+        }
+        else if (fvField(*i) == ecn_yellow_min_threshold_field_name)
+        {
+            attr.id = SAI_WRED_ATTR_ECN_YELLOW_MIN_THRESHOLD;
+            attr.value.s32 = stoi(fvValue(*i));
+            attribs.push_back(attr);
+        }
+        else if (fvField(*i) == ecn_green_max_threshold_field_name)
+        {
+            attr.id = SAI_WRED_ATTR_ECN_GREEN_MAX_THRESHOLD;
+            attr.value.s32 = stoi(fvValue(*i));
+            attribs.push_back(attr);
+        }
+        else if (fvField(*i) == ecn_green_min_threshold_field_name)
+        {
+            attr.id = SAI_WRED_ATTR_ECN_GREEN_MIN_THRESHOLD;
+            attr.value.s32 = stoi(fvValue(*i));
+            attribs.push_back(attr);
+        }
+        else if (fvField(*i) == ecn_red_max_threshold_field_name)
+        {
+            attr.id = SAI_WRED_ATTR_ECN_RED_MAX_THRESHOLD;
+            attr.value.s32 = stoi(fvValue(*i));
+            attribs.push_back(attr);
+        }
+        else if (fvField(*i) == ecn_red_min_threshold_field_name)
+        {
+            attr.id = SAI_WRED_ATTR_ECN_RED_MIN_THRESHOLD;
+            attr.value.s32 = stoi(fvValue(*i));
+            attribs.push_back(attr);
+        }
+        else if (fvField(*i) == ecn_green_mark_probability_field_name)
+        {
+            attr.id = SAI_WRED_ATTR_ECN_GREEN_MARK_PROBABILITY;
+            attr.value.s32 = stoi(fvValue(*i));
+            attribs.push_back(attr);
+        }
+        else if (fvField(*i) == ecn_yellow_mark_probability_field_name)
+        {
+            attr.id = SAI_WRED_ATTR_ECN_YELLOW_MARK_PROBABILITY;
+            attr.value.s32 = stoi(fvValue(*i));
+            attribs.push_back(attr);
+        }
+        else if (fvField(*i) == ecn_red_mark_probability_field_name)
+        {
+            attr.id = SAI_WRED_ATTR_ECN_RED_MARK_PROBABILITY;
+            attr.value.s32 = stoi(fvValue(*i));
+            attribs.push_back(attr);
+        }
         else {
             SWSS_LOG_ERROR("Unknown wred profile field:%s", fvField(*i).c_str());
             return false;
@@ -836,6 +890,15 @@ sai_object_id_t WredMapHandler::addQosItem(const vector<sai_attribute_t> &attrib
         case SAI_WRED_ATTR_RED_DROP_PROBABILITY:
             drop_prob_set |= RED_DROP_PROBABILITY_SET;
             break;
+        case SAI_WRED_ATTR_ECN_GREEN_MARK_PROBABILITY:
+            drop_prob_set |= GREEN_MARK_PROBABILITY_SET;
+            break;
+        case SAI_WRED_ATTR_ECN_YELLOW_MARK_PROBABILITY:
+            drop_prob_set |= YELLOW_MARK_PROBABILITY_SET;
+            break;
+        case SAI_WRED_ATTR_ECN_RED_MARK_PROBABILITY:
+            drop_prob_set |= RED_MARK_PROBABILITY_SET;
+            break;
         default:
             break;
         }
@@ -858,6 +921,30 @@ sai_object_id_t WredMapHandler::addQosItem(const vector<sai_attribute_t> &attrib
         attr.id = SAI_WRED_ATTR_RED_DROP_PROBABILITY;
         attr.value.s32 = 100;
         attrs.push_back(attr);
+    }
+
+    // Only Broadcom switches support green/yellow/red mark probability.
+    string platform = getenv("platform") ? getenv("platform") : "";
+    if (platform == BRCM_PLATFORM_SUBSTRING)
+    {
+        if (!(drop_prob_set & GREEN_MARK_PROBABILITY_SET))
+        {
+            attr.id = SAI_WRED_ATTR_ECN_GREEN_MARK_PROBABILITY;
+            attr.value.s32 = 100;
+            attrs.push_back(attr);
+        }
+        if (!(drop_prob_set & YELLOW_MARK_PROBABILITY_SET))
+        {
+            attr.id = SAI_WRED_ATTR_ECN_YELLOW_MARK_PROBABILITY;
+            attr.value.s32 = 100;
+            attrs.push_back(attr);
+        }
+        if (!(drop_prob_set & RED_MARK_PROBABILITY_SET))
+        {
+            attr.id = SAI_WRED_ATTR_ECN_RED_MARK_PROBABILITY;
+            attr.value.s32 = 100;
+            attrs.push_back(attr);
+        }
     }
 
     sai_status = sai_wred_api->create_wred(&sai_object, gSwitchId, (uint32_t)attrs.size(), attrs.data());

--- a/orchagent/qosorch.h
+++ b/orchagent/qosorch.h
@@ -14,60 +14,70 @@ enum class QosObjectStatus
     FAILURE
 };
 
-const string dscp_to_tc_field_name              = "dscp_to_tc_map";
-const string mpls_tc_to_tc_field_name           = "mpls_tc_to_tc_map";
-const string dot1p_to_tc_field_name             = "dot1p_to_tc_map";
-const string pfc_to_pg_map_name                 = "pfc_to_pg_map";
-const string pfc_to_queue_map_name              = "pfc_to_queue_map";
-const string pfc_enable_name                    = "pfc_enable";
-const string pfcwd_sw_enable_name               = "pfcwd_sw_enable";
-const string tc_to_pg_map_field_name            = "tc_to_pg_map";
-const string tc_to_queue_field_name             = "tc_to_queue_map";
-const string tc_to_dot1p_field_name             = "tc_to_dot1p_map";
-const string tc_to_dscp_field_name              = "tc_to_dscp_map";
-const string scheduler_field_name               = "scheduler";
-const string red_max_threshold_field_name       = "red_max_threshold";
-const string red_min_threshold_field_name       = "red_min_threshold";
-const string yellow_max_threshold_field_name    = "yellow_max_threshold";
-const string yellow_min_threshold_field_name    = "yellow_min_threshold";
-const string green_max_threshold_field_name     = "green_max_threshold";
-const string green_min_threshold_field_name     = "green_min_threshold";
-const string red_drop_probability_field_name    = "red_drop_probability";
-const string yellow_drop_probability_field_name = "yellow_drop_probability";
-const string green_drop_probability_field_name  = "green_drop_probability";
-const string dscp_to_fc_field_name              = "dscp_to_fc_map";
-const string exp_to_fc_field_name               = "exp_to_fc_map";
-const string decap_dscp_to_tc_field_name        = "decap_dscp_to_tc_map";
-const string decap_tc_to_pg_field_name          = "decap_tc_to_pg_map";
-const string encap_tc_to_queue_field_name       = "encap_tc_to_queue_map";
-const string encap_tc_to_dscp_field_name        = "encap_tc_to_dscp_map";
+const string dscp_to_tc_field_name                   = "dscp_to_tc_map";
+const string mpls_tc_to_tc_field_name                = "mpls_tc_to_tc_map";
+const string dot1p_to_tc_field_name                  = "dot1p_to_tc_map";
+const string pfc_to_pg_map_name                      = "pfc_to_pg_map";
+const string pfc_to_queue_map_name                   = "pfc_to_queue_map";
+const string pfc_enable_name                         = "pfc_enable";
+const string pfcwd_sw_enable_name                    = "pfcwd_sw_enable";
+const string tc_to_pg_map_field_name                 = "tc_to_pg_map";
+const string tc_to_queue_field_name                  = "tc_to_queue_map";
+const string tc_to_dot1p_field_name                  = "tc_to_dot1p_map";
+const string tc_to_dscp_field_name                   = "tc_to_dscp_map";
+const string scheduler_field_name                    = "scheduler";
+const string ing_scheduler_field_name                = "ing_scheduler";
+const string red_max_threshold_field_name            = "red_max_threshold";
+const string red_min_threshold_field_name            = "red_min_threshold";
+const string yellow_max_threshold_field_name         = "yellow_max_threshold";
+const string yellow_min_threshold_field_name         = "yellow_min_threshold";
+const string green_max_threshold_field_name          = "green_max_threshold";
+const string green_min_threshold_field_name          = "green_min_threshold";
+const string red_drop_probability_field_name         = "red_drop_probability";
+const string yellow_drop_probability_field_name      = "yellow_drop_probability";
+const string green_drop_probability_field_name       = "green_drop_probability";
+const string ecn_red_max_threshold_field_name        = "ecn_red_max_threshold";
+const string ecn_red_min_threshold_field_name        = "ecn_red_min_threshold";
+const string ecn_yellow_max_threshold_field_name     = "ecn_yellow_max_threshold";
+const string ecn_yellow_min_threshold_field_name     = "ecn_yellow_min_threshold";
+const string ecn_green_max_threshold_field_name      = "ecn_green_max_threshold";
+const string ecn_green_min_threshold_field_name      = "ecn_green_min_threshold";
+const string ecn_red_mark_probability_field_name     = "ecn_red_mark_probability";
+const string ecn_yellow_mark_probability_field_name  = "ecn_yellow_mark_probability";
+const string ecn_green_mark_probability_field_name   = "ecn_green_mark_probability";
+const string dscp_to_fc_field_name                   = "dscp_to_fc_map";
+const string exp_to_fc_field_name                    = "exp_to_fc_map";
+const string decap_dscp_to_tc_field_name             = "decap_dscp_to_tc_map";
+const string decap_tc_to_pg_field_name               = "decap_tc_to_pg_map";
+const string encap_tc_to_queue_field_name            = "encap_tc_to_queue_map";
+const string encap_tc_to_dscp_field_name             = "encap_tc_to_dscp_map";
 
-const string wred_profile_field_name            = "wred_profile";
-const string wred_red_enable_field_name         = "wred_red_enable";
-const string wred_yellow_enable_field_name      = "wred_yellow_enable";
-const string wred_green_enable_field_name       = "wred_green_enable";
+const string wred_profile_field_name                 = "wred_profile";
+const string wred_red_enable_field_name              = "wred_red_enable";
+const string wred_yellow_enable_field_name           = "wred_yellow_enable";
+const string wred_green_enable_field_name            = "wred_green_enable";
 
-const string scheduler_algo_type_field_name     = "type";
-const string scheduler_algo_DWRR                = "DWRR";
-const string scheduler_algo_WRR                 = "WRR";
-const string scheduler_algo_STRICT              = "STRICT";
-const string scheduler_weight_field_name        = "weight";
-const string scheduler_meter_type_field_name    = "meter_type";
+const string scheduler_algo_type_field_name          = "type";
+const string scheduler_algo_DWRR                     = "DWRR";
+const string scheduler_algo_WRR                      = "WRR";
+const string scheduler_algo_STRICT                   = "STRICT";
+const string scheduler_weight_field_name             = "weight";
+const string scheduler_meter_type_field_name         = "meter_type";
 
 const string scheduler_min_bandwidth_rate_field_name       = "cir";//Committed Information Rate
 const string scheduler_min_bandwidth_burst_rate_field_name = "cbs";//Committed Burst Size
 const string scheduler_max_bandwidth_rate_field_name       = "pir";//Peak Information Rate
 const string scheduler_max_bandwidth_burst_rate_field_name = "pbs";//Peak Burst Size
 
-const string ecn_field_name                     = "ecn";
-const string ecn_none                           = "ecn_none";
-const string ecn_red                            = "ecn_red";
-const string ecn_yellow                         = "ecn_yellow";
-const string ecn_yellow_red                     = "ecn_yellow_red";
-const string ecn_green                          = "ecn_green";
-const string ecn_green_red                      = "ecn_green_red";
-const string ecn_green_yellow                   = "ecn_green_yellow";
-const string ecn_all                            = "ecn_all";
+const string ecn_field_name                          = "ecn";
+const string ecn_none                                = "ecn_none";
+const string ecn_red                                 = "ecn_red";
+const string ecn_yellow                              = "ecn_yellow";
+const string ecn_yellow_red                          = "ecn_yellow_red";
+const string ecn_green                               = "ecn_green";
+const string ecn_green_red                           = "ecn_green_red";
+const string ecn_green_yellow                        = "ecn_green_yellow";
+const string ecn_all                                 = "ecn_all";
 
 class QosMapHandler
 {


### PR DESCRIPTION
**What I did**
Support the ECN-marked attribute for separate WRED and ECN configurations.

**Why I did it**

**How I verified it**
Run test_ecn.py to verify that the configuration has been successfully applied.

**Details if related**
