### PR TITLE
[portsorch] Set router interface MAC only if it changes

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -4489,7 +4489,7 @@ void PortsOrch::doVlanTask(Consumer &consumer)
                         gIntfsOrch->setRouterIntfsMtu(vl);
                     }
                 }
-                if (mac)
+                if (mac && vl.m_mac != mac)
                 {
                     vl.m_mac = mac;
                     m_portList[vlan_alias] = vl;


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Set router interface MAC only if it changes

**Why I did it**
Avoid setting SAI_ROUTER_INTERFACE_ATTR_SRC_MAC_ADDRESS when it is not supported

**How I verified it**
N/A

**Details if related**
N/A