### PR TITLE
When a learn event is received, update the MAC entry to static with allow mac move if the entry already exists

### DIFF
--- a/orchagent/fdborch.cpp
+++ b/orchagent/fdborch.cpp
@@ -404,10 +404,8 @@ void FdbOrch::update(sai_fdb_event_t        type,
                 {
                     SWSS_LOG_NOTICE("FdbOrch LEARN notification: mac %s is already in bv_id 0x%" PRIx64 "with same bp 0x%" PRIx64,
                             update.entry.mac.to_string().c_str(), entry->bv_id, existing_entry->second.bridge_port_id);
-                    // Continue to move the MAC as local.
-
-                    // Existing MAC entry is on same VLAN, Port with Origin MCLAG(remote), its possible after the local learn MAC in
-                    //the HW is updated to remote from FdbOrch, Update the MAC back to local in HW so that FdbOrch and HW is Sync and aging enabled.
+                    // Keep the static type allow port move.
+                    // Existing MAC entry is on same VLAN, Port with Origin MCLAG(remote), update the MAC to HW based on FdbOrch.
                     sai_status_t status;
                     sai_fdb_entry_t fdb_entry;
                     fdb_entry.switch_id = gSwitchId;
@@ -417,8 +415,11 @@ void FdbOrch::update(sai_fdb_event_t        type,
                     vector<sai_attribute_t> attrs;
 
                     attr.id = SAI_FDB_ENTRY_ATTR_TYPE;
-                    attr.value.s32 = SAI_FDB_ENTRY_TYPE_DYNAMIC;
-                    update.sai_fdb_type = SAI_FDB_ENTRY_TYPE_DYNAMIC;
+                    attr.value.s32 = SAI_FDB_ENTRY_TYPE_STATIC;
+                    attrs.push_back(attr);
+
+                    attr.id = SAI_FDB_ENTRY_ATTR_ALLOW_MAC_MOVE;
+                    attr.value.booldata = true;
                     attrs.push_back(attr);
 
                     attr.id = SAI_FDB_ENTRY_ATTR_BRIDGE_PORT_ID;
@@ -434,10 +435,6 @@ void FdbOrch::update(sai_fdb_event_t        type,
                                         itr.id, update.entry.mac.to_string().c_str(), entry->bv_id, update.port.m_alias.c_str(), status);
                         }
                     }
-                    update.add = true;
-                    update.type = "dynamic";
-                    storeFdbEntryState(update);
-                    notify(SUBJECT_TYPE_FDB_CHANGE, &update);
 
                     return;
                 }


### PR DESCRIPTION


<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
When a learn event is received, keep the mesh type if the entry already exists and is a mesh type

**Why I did it**
N/A

**How I verified it**
N/A

**Details if related**
N/A