### PR TITLE
Not sending the connected host route to the FPM

### DIFF
--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -135,6 +135,27 @@ bool IntfsOrch::isPrefixSubnet(const IpPrefix &ip_prefix, const string &alias)
     return false;
 }
 
+bool IntfsOrch::isIp2MeRoute(const IpPrefix &ip_prefix, const string &alias)
+{
+    SWSS_LOG_INFO("Checking whether the ip_prefix matches any IP2me route for the alias [%s]", alias);
+    if (m_syncdIntfses.find(alias) == m_syncdIntfses.end())
+    {
+        return false;
+    }
+
+    for (auto &prefixIt: m_syncdIntfses[alias].ip_addresses)
+    {
+        SWSS_LOG_DEBUG("ip_prefix = [%s]", ip_prefix.to_string().c_str());
+        SWSS_LOG_DEBUG("prefixIt in alias [%s] = [%s]", alias, prefixIt.to_string().c_str());
+        if (prefixIt.getIp() == ip_prefix.getIp())
+        {
+            SWSS_LOG_INFO("The ip_prefix is the same as the IP2me route of the alias [%s]", alias);
+            return true;
+        }
+    }
+    return false;
+}
+
 string IntfsOrch::getRouterIntfsAlias(const IpAddress &ip, const string &vrf_name)
 {
     sai_object_id_t vrf_id = gVirtualRouterId;

--- a/orchagent/intfsorch.h
+++ b/orchagent/intfsorch.h
@@ -36,6 +36,7 @@ public:
 
     sai_object_id_t getRouterIntfsId(const string&);
     bool isPrefixSubnet(const IpPrefix&, const string&);
+    bool isIp2MeRoute(const IpPrefix&, const string&);
     bool isInbandIntfInMgmtVrf(const string& alias);
     string getRouterIntfsAlias(const IpAddress &ip, const string &vrf_name = "");
     bool isIpInIntfSubnet(const IpAddress &ip, const string &alias, const string &vrf_name);

--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -848,8 +848,8 @@ void RouteOrch::doTask(Consumer& consumer)
                     {
                         it = consumer.m_toSync.erase(it);
                     }
-                    /* fullmask subnet route is not allowed */
-                    else if (ip_prefix.isFullMask())
+                    /* skip prefix which is fullmask subnet route and is Prefix Subnet or Ip2Me route */
+                    else if (ip_prefix.isFullMask() && (m_intfsOrch->isPrefixSubnet(ip_prefix, alsv[0]) || m_intfsOrch->isIp2MeRoute(ip_prefix, alsv[0])))
                     {
                         it = consumer.m_toSync.erase(it);
                     }


### PR DESCRIPTION
[ec202311][swss] Not sending the connected host route to the FPM

#### Why I did it
Due to the FRR checkin https://github.com/FRRouting/frr/pull/12600,
we are now installing a new host route for every connected route (along with the subnet route).
However, the orchagent already installs a host route for a connected interface address
1.Block connected host route in orchestrant.

#### How I did it
N/A

#### How to verify it
N/A