### PR TITLE
when del DIP tunnel user, del SIP tunnel port if it's not referenced

### DIFF
--- a/orchagent/vxlanorch.cpp
+++ b/orchagent/vxlanorch.cpp
@@ -1671,7 +1671,19 @@ bool  VxlanTunnelOrch::delTunnelUser(const std::string remote_vtep, uint32_t vni
     vtep_ptr->deleteDynamicDIPTunnel(remote_vtep, usr);
     SWSS_LOG_NOTICE("diprefcnt for remote %s = %d",
                      remote_vtep.c_str(), vtep_ptr->getRemoteEndPointRefCnt(remote_vtep));
-
+    if (vtep_ptr->del_tnl_hw_pending && !vtep_ptr->isTunnelReferenced())
+    {
+        port_tunnel_name = getTunnelPortName(vtep_ptr->getSrcIP().to_string(), true);
+        gPortsOrch->getPort(port_tunnel_name,tunnelPort);
+        bool ret = gPortsOrch->removeBridgePort(tunnelPort);
+        if (!ret)
+        {
+            SWSS_LOG_ERROR("Remove Bridge port failed for source vtep = %s fdbcount = %d",
+                           port_tunnel_name.c_str(), tunnelPort.m_fdb_count);
+            return true;
+        }
+        gPortsOrch->removeTunnel(tunnelPort);
+    }
     vtep_ptr->deletePendingSIPTunnel();
 
     return true;


### PR DESCRIPTION
When vlan-vni map removed while tunnel is up, the SIP tunnel bridge port will not been removed and caused tunnel remove fail. 

**What I did**

Fix tunnel termination is deleted but tunnel remove fail due to refcount is 1 ( bridge port)

**Why I did it**

Add code to to check SIP tunnel bridge reference and remove local tunnel port in p2p tunnel remove.

**How I verified it**

N/A

**Details if related**

N/A