### PR TITLE
Clear the VLAN member database stored in the mclag local when deleting a domain

### DIFF
--- a/mclagsyncd/mclaglink.cpp
+++ b/mclagsyncd/mclaglink.cpp
@@ -1043,6 +1043,7 @@ void MclagLink::delDomainCfgDependentSelectables()
 
         delete p_state_vlan_mbr_subscriber_table;
         p_state_vlan_mbr_subscriber_table = NULL;
+        m_vlan_mbrship.clear();
     }
 }
 


### PR DESCRIPTION


<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Clear the VLAN member database stored in the mclag local when deleting a domain.

**Why I did it**
Deleting VLAN members after removing mclag resulted in the VLAN members stored in the mclag local database not being removed.
When adding back the VLAN member, mclag would not update it as there was no change detected, causing the synchronization of ARP to the peer with an all-zero MAC address, session going down.

**How I verified it**
N/A

**Details if related**
N/A