### PR TITLE
Check if all IP addresses have been removed when optimization occurs

### DIFF
--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -546,10 +546,7 @@ bool IntfsOrch::setIntf(const string& alias, sai_object_id_t vrf_id, const IpPre
 
         if (!ip_prefix && (m_syncdIntfses[alias].vrf_id != vrf_id))
         {
-            if (m_syncdIntfses[alias].ip_addresses.size() == 0)
-            {
-                removeIntf(alias, m_syncdIntfses[alias].vrf_id, nullptr);
-            }
+            removeIntf(alias, m_syncdIntfses[alias].vrf_id, nullptr);
             return false;
         }
 
@@ -655,6 +652,29 @@ bool IntfsOrch::removeIntf(const string& alias, sai_object_id_t vrf_id, const Ip
 
     if (!ip_prefix)
     {
+        if (m_syncdIntfses[alias].ip_addresses.size() != 0)
+        {
+            for (auto it = m_syncdIntfses[alias].ip_addresses.begin(); it != m_syncdIntfses[alias].ip_addresses.end(); )
+            {
+                removeIp2MeRoute(port.m_vr_id, *it);
+
+                if (gMySwitchType == "voq")
+                {
+                    if (gPortsOrch->isInbandPort(alias))
+                    {
+                        gNeighOrch->delInbandNeighbor(alias, it->getIp());
+                    }
+                }
+
+                if (port.m_type == Port::VLAN)
+                {
+                    removeDirectedBroadcast(port, *it);
+                }
+
+                it = m_syncdIntfses[alias].ip_addresses.erase(it);
+            }
+        }
+
         if (m_syncdIntfses[alias].ip_addresses.size() == 0 && removeRouterIntfs(port))
         {
             gPortsOrch->decreasePortRefCount(alias);


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Check if all IP addresses have been removed when optimization occurs

**Why I did it**
When got the publish msg of the DEL,the ConsumerStateTable::pops msg would judge it as SET_COMMAND, because the next SET msg had aleady set the value to the key

**How I verified it**
N/A

**Details if related**
N/A