### PR TITLE
[swss] Change loglevel to WARN for unsupported attribute

### DIFF
--- a/orchagent/switchorch.cpp
+++ b/orchagent/switchorch.cpp
@@ -477,7 +477,7 @@ void SwitchOrch::doAppSwitchTableTask(Consumer &consumer)
                     break;
                 }
                 if (unsupported_attr){
-                    SWSS_LOG_ERROR("Unsupported Attribute %s", attribute.c_str());
+                    SWSS_LOG_WARN("Unsupported Attribute %s", attribute.c_str());
                     // Continue to set the rest of the attributes, even if current attribute is unsupported
                     continue;
                 }


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->
**Why I did it**
Fix the following syslog which may cause sonic-mgmt log analyzer failure:
ERR swss#orchagent: :- doAppSwitchTableTask: Unsupported Attribute ecmp_hash_offset

**How I did it**
Change loglevel to WARN.

**How I verified it**
Check syslog
