### PR TITLE
[Buffer] Changing the context of the "show queue watermark" command from a shared watermark (SAI_QUEUE_STAT_SHARED WATERMARK_BYTES) to a total watermark (SAI_QUEUE_STAT_WATERMARK_BYTES).

### DIFF
--- a/orchagent/bufferorch.cpp
+++ b/orchagent/bufferorch.cpp
@@ -279,6 +279,61 @@ void BufferOrch::clearBufferPoolWatermarkCounterIdList(const sai_object_id_t obj
     }
 }
 
+void BufferOrch::updateBufferPoolWatermarkCounterIdList(const sai_object_id_t object_id)
+{
+    if (m_isBufferPoolWatermarkCounterIdListGenerated)
+    {
+        bool isSupportClear = true;
+        sai_status_t status = sai_buffer_api->clear_buffer_pool_stats(
+            object_id,
+            static_cast<uint32_t>(bufferPoolWatermarkStatIds.size()),
+            reinterpret_cast<const sai_stat_id_t*>(bufferPoolWatermarkStatIds.data()));
+        if (status == SAI_STATUS_NOT_SUPPORTED || status == SAI_STATUS_NOT_IMPLEMENTED)
+        {
+            SWSS_LOG_NOTICE("Clear watermark failed on %s, rv: %s",
+                            sai_serialize_object_id(object_id).c_str(),
+                            sai_serialize_status(status).c_str());
+            isSupportClear = false;
+        }
+
+        if (isSupportClear)
+        {
+            vector<FieldValueTuple> fvs;
+
+            fvs.emplace_back(STATS_MODE_FIELD, STATS_MODE_READ_AND_CLEAR);
+            m_flexCounterGroupTable->set(BUFFER_POOL_WATERMARK_STAT_COUNTER_FLEX_COUNTER_GROUP, fvs);
+        }
+
+        // Create a buffer pool watermark to FLEX_COUNTER_TABLE.
+        string key = BUFFER_POOL_WATERMARK_STAT_COUNTER_FLEX_COUNTER_GROUP ":" + sai_serialize_object_id(object_id);
+        vector<FieldValueTuple> fvTuples;
+
+        {
+            string statList;
+
+            for (const auto& it : bufferPoolWatermarkStatIds)
+            {
+                statList += (sai_serialize_buffer_pool_stat(it) + list_item_delimiter);
+            }
+
+            if (!statList.empty())
+            {
+                statList.pop_back();
+            }
+
+            fvTuples.emplace_back(BUFFER_POOL_COUNTER_ID_LIST, statList);
+        }
+
+        if (!isSupportClear)
+        {
+            string stats_mode = STATS_MODE_READ;
+            fvTuples.emplace_back(STATS_MODE_FIELD, stats_mode);
+        }
+
+        m_flexCounterTable->set(key, fvTuples);
+    }
+}
+
 void BufferOrch::generateBufferPoolWatermarkCounterIdList(void)
 {
     // This function will be called in FlexCounterOrch when field:value tuple "FLEX_COUNTER_STATUS":"enable"
@@ -525,6 +580,8 @@ task_process_status BufferOrch::processBufferPool(KeyOpFieldsValuesTuple &tuple)
             // In pg and queue case, this mapping installment is deferred to FlexCounterOrch at a reception of field
             // "FLEX_COUNTER_STATUS"
             m_countersDb->hset(COUNTERS_BUFFER_POOL_NAME_MAP, object_name, sai_serialize_object_id(sai_object));
+
+            updateBufferPoolWatermarkCounterIdList(sai_object);
         }
 
         // Only publish the result when shared headroom pool is enabled and it has been successfully applied to SAI

--- a/orchagent/bufferorch.h
+++ b/orchagent/bufferorch.h
@@ -46,6 +46,7 @@ private:
     void doTask() override;
     virtual void doTask(Consumer& consumer);
     void clearBufferPoolWatermarkCounterIdList(const sai_object_id_t object_id);
+    void updateBufferPoolWatermarkCounterIdList(const sai_object_id_t object_id);
     void initTableHandlers();
     void initBufferReadyLists(DBConnector *confDb, DBConnector *applDb);
     void initBufferReadyList(Table& table, bool isConfigDb);

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -258,7 +258,7 @@ static const vector<sai_queue_stat_t> queue_stat_ids =
 
 static const vector<sai_queue_stat_t> queueWatermarkStatIds =
 {
-    SAI_QUEUE_STAT_SHARED_WATERMARK_BYTES,
+    SAI_QUEUE_STAT_WATERMARK_BYTES,
 };
 
 static const vector<sai_ingress_priority_group_stat_t> ingressPriorityGroupWatermarkStatIds =

--- a/orchagent/watermark_queue.lua
+++ b/orchagent/watermark_queue.lua
@@ -19,18 +19,18 @@ redis.call('SELECT', counters_db)
 local n = table.getn(KEYS)
 for i = n, 1, -1 do
     -- Gen new WM value
-    local queue_shared_wm = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'SAI_QUEUE_STAT_SHARED_WATERMARK_BYTES')
+    local queue_shared_wm = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'SAI_QUEUE_STAT_WATERMARK_BYTES')
 
     -- Get the last values in the other tables (assume 0 if does not exist)
-    local periodic_shared_wm = redis.call('HGET', periodic_table_name .. ':' .. KEYS[i], 'SAI_QUEUE_STAT_SHARED_WATERMARK_BYTES') 
-    local persistent_shared_wm = redis.call('HGET', persistent_table_name .. ':' .. KEYS[i], 'SAI_QUEUE_STAT_SHARED_WATERMARK_BYTES')
-    local user_shared_wm = redis.call('HGET', user_table_name .. ':' .. KEYS[i], 'SAI_QUEUE_STAT_SHARED_WATERMARK_BYTES') 
+    local periodic_shared_wm = redis.call('HGET', periodic_table_name .. ':' .. KEYS[i], 'SAI_QUEUE_STAT_WATERMARK_BYTES') 
+    local persistent_shared_wm = redis.call('HGET', persistent_table_name .. ':' .. KEYS[i], 'SAI_QUEUE_STAT_WATERMARK_BYTES')
+    local user_shared_wm = redis.call('HGET', user_table_name .. ':' .. KEYS[i], 'SAI_QUEUE_STAT_WATERMARK_BYTES') 
 
     -- Set the values into the other tables. Make comparioson, if th evalue was absent in COUNTERS, set to N/A
     if tonumber(queue_shared_wm) then
-        redis.call('HSET', periodic_table_name .. ':' .. KEYS[i], 'SAI_QUEUE_STAT_SHARED_WATERMARK_BYTES', periodic_shared_wm and math.max(queue_shared_wm, periodic_shared_wm) or queue_shared_wm)
-        redis.call('HSET', persistent_table_name .. ':' .. KEYS[i], 'SAI_QUEUE_STAT_SHARED_WATERMARK_BYTES', persistent_shared_wm and math.max(queue_shared_wm, persistent_shared_wm) or queue_shared_wm)
-        redis.call('HSET', user_table_name .. ':' .. KEYS[i], 'SAI_QUEUE_STAT_SHARED_WATERMARK_BYTES', user_shared_wm and math.max(queue_shared_wm, user_shared_wm) or queue_shared_wm)
+        redis.call('HSET', periodic_table_name .. ':' .. KEYS[i], 'SAI_QUEUE_STAT_WATERMARK_BYTES', periodic_shared_wm and math.max(queue_shared_wm, periodic_shared_wm) or queue_shared_wm)
+        redis.call('HSET', persistent_table_name .. ':' .. KEYS[i], 'SAI_QUEUE_STAT_WATERMARK_BYTES', persistent_shared_wm and math.max(queue_shared_wm, persistent_shared_wm) or queue_shared_wm)
+        redis.call('HSET', user_table_name .. ':' .. KEYS[i], 'SAI_QUEUE_STAT_WATERMARK_BYTES', user_shared_wm and math.max(queue_shared_wm, user_shared_wm) or queue_shared_wm)
     end
 end
 

--- a/orchagent/watermarkorch.cpp
+++ b/orchagent/watermarkorch.cpp
@@ -196,19 +196,19 @@ void WatermarkOrch::doTask(NotificationConsumer &consumer)
     else if (data == CLEAR_QUEUE_SHARED_UNI_REQUEST)
     {
         clearSingleWm(table,
-                      "SAI_QUEUE_STAT_SHARED_WATERMARK_BYTES",
+                      "SAI_QUEUE_STAT_WATERMARK_BYTES",
                       m_unicast_queue_ids);
     }
     else if (data == CLEAR_QUEUE_SHARED_MULTI_REQUEST)
     {
         clearSingleWm(table,
-                      "SAI_QUEUE_STAT_SHARED_WATERMARK_BYTES",
+                      "SAI_QUEUE_STAT_WATERMARK_BYTES",
                       m_multicast_queue_ids);
     }
     else if (data == CLEAR_QUEUE_SHARED_ALL_REQUEST)
     {
         clearSingleWm(table,
-                      "SAI_QUEUE_STAT_SHARED_WATERMARK_BYTES",
+                      "SAI_QUEUE_STAT_WATERMARK_BYTES",
                       m_all_queue_ids);
     }
     else if (data == CLEAR_BUFFER_POOL_REQUEST)
@@ -263,13 +263,13 @@ void WatermarkOrch::doTask(SelectableTimer &timer)
                       "SAI_INGRESS_PRIORITY_GROUP_STAT_SHARED_WATERMARK_BYTES",
                       m_pg_ids);
         clearSingleWm(m_periodicWatermarkTable.get(),
-                      "SAI_QUEUE_STAT_SHARED_WATERMARK_BYTES",
+                      "SAI_QUEUE_STAT_WATERMARK_BYTES",
                       m_unicast_queue_ids);
         clearSingleWm(m_periodicWatermarkTable.get(),
-                      "SAI_QUEUE_STAT_SHARED_WATERMARK_BYTES",
+                      "SAI_QUEUE_STAT_WATERMARK_BYTES",
                       m_multicast_queue_ids);
         clearSingleWm(m_periodicWatermarkTable.get(),
-                      "SAI_QUEUE_STAT_SHARED_WATERMARK_BYTES",
+                      "SAI_QUEUE_STAT_WATERMARK_BYTES",
                       m_all_queue_ids);
         clearSingleWm(m_periodicWatermarkTable.get(),
                       "SAI_BUFFER_POOL_STAT_WATERMARK_BYTES",

--- a/tests/test_watermark.py
+++ b/tests/test_watermark.py
@@ -8,7 +8,7 @@ import redis
 from swsscommon import swsscommon
 
 class SaiWmStats:
-    queue_shared = "SAI_QUEUE_STAT_SHARED_WATERMARK_BYTES"
+    queue_shared = "SAI_QUEUE_STAT_WATERMARK_BYTES"
     pg_shared = "SAI_INGRESS_PRIORITY_GROUP_STAT_SHARED_WATERMARK_BYTES"
     pg_headroom = "SAI_INGRESS_PRIORITY_GROUP_STAT_XOFF_ROOM_WATERMARK_BYTES"
     buffer_pool = "SAI_BUFFER_POOL_STAT_WATERMARK_BYTES"


### PR DESCRIPTION
**What I did**
* While user creating a new buffer pool, also create the related flexcounter.

* Changing the context of the "show queue watermark" command from a shared watermark (SAI_QUEUE_STAT_SHARED WATERMARK_BYTES) to a total watermark (SAI_QUEUE_STAT_WATERMARK_BYTES).


**Why I did it**
* The flex counter for the buffer pool is only created once during startup. If users dynamically configure the buffer pool, they must save the configuration and restart to see the buffer pool's watermark.

* Designed change due to chip limitation.

**How I verified it**
* Clear and reapply the buffer configuration twice to verify that the pool watermark functions correctly.
* Using the test_shared_buffer.py to verify the queue watermark has been changed total watermark.



**Details if related**
