### PR TITLE
Fix the problem that lag members may not be added

### DIFF
--- a/orchagent/port.h
+++ b/orchagent/port.h
@@ -141,7 +141,7 @@ public:
     VlanInfo            m_vlan_info;
     MacAddress          m_mac;
     sai_object_id_t     m_bridge_port_id = 0;   // TODO: port could have multiple bridge port IDs
-    sai_object_id_t     m_bridge_port_admin_state = 0;   // TODO: port could have multiple bridge port IDs
+    bool                m_bridge_port_admin_state = false;   // TODO: port could have multiple bridge port IDs
     sai_vlan_id_t       m_port_vlan_id = DEFAULT_PORT_VLAN_ID;  // Port VLAN ID
     sai_object_id_t     m_rif_id = 0;
     sai_object_id_t     m_vr_id = 0;

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -5612,11 +5612,6 @@ bool PortsOrch::addBridgePort(Port &port)
 {
     SWSS_LOG_ENTER();
 
-    if (port.m_bridge_port_id != SAI_NULL_OBJECT_ID)
-    {
-        return true;
-    }
-
     if (port.m_rif_id != 0)
     {
         SWSS_LOG_NOTICE("Cannot create bridge port, interface %s is a router port", port.m_alias.c_str());
@@ -5625,6 +5620,49 @@ bool PortsOrch::addBridgePort(Port &port)
 
     sai_attribute_t attr;
     vector<sai_attribute_t> attrs;
+
+    if (port.m_bridge_port_id != SAI_NULL_OBJECT_ID)
+    {
+        if (port.m_bridge_port_admin_state == true)
+        {
+            return true;
+        }
+        else
+        {
+            /* Set bridge port admin status to UP */
+            attr.id = SAI_BRIDGE_PORT_ATTR_ADMIN_STATE;
+            attr.value.booldata = true;
+            sai_status_t status = sai_bridge_api->set_bridge_port_attribute(port.m_bridge_port_id, &attr);
+            if (status != SAI_STATUS_SUCCESS)
+            {
+                SWSS_LOG_ERROR("Failed to set bridge port %s admin status to UP, rv:%d",
+                    port.m_alias.c_str(), status);
+                task_process_status handle_status = handleSaiSetStatus(SAI_API_BRIDGE, status);
+                if (handle_status != task_success)
+                {
+                    return parseHandleSaiStatusFailure(handle_status);
+                }
+            }
+            port.m_bridge_port_admin_state = true;
+            m_portList[port.m_alias] = port;
+
+            /* And with hardware FDB learning mode set to HW (explicit default value) */
+            attr.id = SAI_BRIDGE_PORT_ATTR_FDB_LEARNING_MODE;
+            attr.value.s32 = port.m_learn_mode;
+            status = sai_bridge_api->set_bridge_port_attribute(port.m_bridge_port_id, &attr);
+            if (status != SAI_STATUS_SUCCESS)
+            {
+                SWSS_LOG_ERROR("Failed to set bridge port %s learning mode, rv:%d",
+                    port.m_alias.c_str(), status);
+                task_process_status handle_status = handleSaiSetStatus(SAI_API_BRIDGE, status);
+                if (handle_status != task_success)
+                {
+                    return parseHandleSaiStatusFailure(handle_status);
+                }
+            }
+            return true;
+        }
+    }
 
     if (port.m_type == Port::PHY)
     {
@@ -5688,6 +5726,8 @@ bool PortsOrch::addBridgePort(Port &port)
             return parseHandleSaiStatusFailure(handle_status);
         }
     }
+    port.m_bridge_port_admin_state = true;
+    m_portList[port.m_alias] = port;
 
     if (!setHostIntfsStripTag(port, SAI_HOSTIF_VLAN_TAG_KEEP))
     {
@@ -5729,6 +5769,10 @@ bool PortsOrch::removeBridgePort(Port &port)
             return parseHandleSaiStatusFailure(handle_status);
         }
     }
+
+    port.m_bridge_port_admin_state = false;
+    m_portList[port.m_alias] = port;
+
     if (port.m_child_ports.empty())
     {
         if (!setHostIntfsStripTag(port, SAI_HOSTIF_VLAN_TAG_STRIP))


### PR DESCRIPTION
Restore bridge port admin state when a bridge port is re-added but not completely removed
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Restore bridge port admin state when a bridge port is re-added but not completely removed
**Why I did it**
for some reason the fdb flush does not complete, orchagent will retry until all MACs are cleaned up.
If this port is added to the vlan during retry fdb flush, the bridge port has not been removed,
so it will be added directly to the vlan, but the bridgeport admin status is still down
**How I verified it**
**Details if related**
