### PR TITLE
When the LAG operation status is not enabled, set the operation of all LAG members to disabled

### DIFF
--- a/teamsyncd/teamsync.cpp
+++ b/teamsyncd/teamsync.cpp
@@ -162,10 +162,15 @@ void TeamSync::addLag(const string &lagName, int ifindex, bool admin_state,
     if (m_teamSelectables.find(lagName) != m_teamSelectables.end())
     {
         auto tsync = m_teamSelectables[lagName];
-        if (tsync->admin_state == admin_state && tsync->mtu == mtu)
+        if (tsync->admin_state == admin_state && tsync->mtu == mtu && tsync->lag_oper_status == oper_state)
             return;
         tsync->admin_state = admin_state;
         tsync->mtu = mtu;
+        if (tsync->lag_oper_status != oper_state)
+        {
+            tsync->lag_oper_status = oper_state;
+            tsync->operUpdate();
+        }
         lag_update = false;
     }
 
@@ -337,7 +342,8 @@ int TeamSync::TeamPortSync::onChange()
         }
 
         team_get_port_enabled(m_team, ifindex, &enabled);
-        tmp_lag_members[string(ifname)] = enabled;
+        // If lag oper status not up, all lag members should not be enabled
+        tmp_lag_members[string(ifname)] = lag_oper_status && enabled;
     }
 
     /* Compare old and new LAG members and set/del accordingly */
@@ -371,6 +377,11 @@ int TeamSync::TeamPortSync::onChange()
     /* Replace the old LAG members with the new ones */
     m_lagMembers = tmp_lag_members;
     return 0;
+}
+
+int TeamSync::TeamPortSync::operUpdate()
+{
+    return this->onChange();
 }
 
 int TeamSync::TeamPortSync::teamdHandler(struct team_handle *team, void *arg,

--- a/teamsyncd/teamsync.h
+++ b/teamsyncd/teamsync.h
@@ -40,10 +40,12 @@ public:
 
         int getFd() override;
         uint64_t readData() override;
+        int operUpdate();
 
         /* member_name -> enabled|disabled */
         std::map<std::string, bool> m_lagMembers;
         bool admin_state;
+        bool lag_oper_status;
         unsigned int mtu;
     protected:
         int onChange();


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
If lag oper status not up, set all lag members oper down.
**Why I did it**
If lag oper status not up, all lag members should not be enabled
**How I verified it**

**Details if related**
