### PR TITLE
[vxlanorch] Add safety checks for VTEP management and EVPN interaction

### DIFF
--- a/orchagent/vxlanorch.cpp
+++ b/orchagent/vxlanorch.cpp
@@ -1538,6 +1538,7 @@ bool VxlanTunnelOrch::delOperation(const Request& request)
     SWSS_LOG_ENTER();
 
     const auto& tunnel_name = request.getKeyString(0);
+    EvpnNvoOrch* evpn_orch = gDirectory.get<EvpnNvoOrch*>();
 
     if (!isTunnelExists(tunnel_name))
     {
@@ -1550,6 +1551,26 @@ bool VxlanTunnelOrch::delOperation(const Request& request)
     {
         SWSS_LOG_WARN("VTEP %s not deleted as hw delete is pending", tunnel_name.c_str());
         return false;
+    }
+
+    if (vtep_ptr == evpn_orch->getEVPNVtep())
+    {
+        for (auto it = vxlan_tunnel_table_.begin(); it != vxlan_tunnel_table_.end(); ++it)
+        {
+            if ((it->second.get() != vtep_ptr) || (it->second->getDipTunnelCnt() != 0)  )
+            {
+                SWSS_LOG_WARN("VTEP %s not deleted as there is user tuunel still in used", tunnel_name.c_str());
+                return false;
+            }
+        }
+
+        if (0 != vxlan_vni_vlan_map_table_.size() )
+        {
+            SWSS_LOG_WARN("VTEP %s not deleted as there is vlan vni map still in used", tunnel_name.c_str());
+            return false;
+        }
+
+        evpn_orch->delEVPNVtep();
     }
 
     vxlan_tunnel_table_.erase(tunnel_name);
@@ -2748,6 +2769,10 @@ bool EvpnNvoOrch::delOperation(const Request& request)
 
     auto nvo_name = request.getKeyString(0);
 
+    VxlanTunnelOrch* tunnel_orch = gDirectory.get<VxlanTunnelOrch*>();
+    auto tunnel_size = tunnel_orch->getVxlanTunnelSize();
+    auto vni_vlan_map_size = tunnel_orch->getVniVlanMapTableSize();
+
     if (!source_vtep_ptr) 
     {
         SWSS_LOG_WARN("NVO Delete failed as VTEP Ptr is NULL");
@@ -2757,6 +2782,18 @@ bool EvpnNvoOrch::delOperation(const Request& request)
     if (source_vtep_ptr->del_tnl_hw_pending)
     {
         SWSS_LOG_WARN("NVO not deleted as hw delete is pending");
+        return false;
+    }
+
+    if (tunnel_size != 0)
+    {
+        SWSS_LOG_WARN("NVO not deleted as there is user tuunel still in used");
+        return false;
+    }
+
+    if (vni_vlan_map_size != 0)
+    {
+        SWSS_LOG_WARN("NVO not deleted as there is vni vlan map still in used");
         return false;
     }
 

--- a/orchagent/vxlanorch.h
+++ b/orchagent/vxlanorch.h
@@ -274,6 +274,11 @@ public:
         return vxlan_tunnel_table_.at(tunnelName).get();
     }
 
+    auto getVxlanTunnelSize()
+    {
+        return vxlan_tunnel_table_.size();
+    }
+
     bool addTunnel(const std::string tunnel_name,VxlanTunnel* tnlptr)
     {
        vxlan_tunnel_table_[tunnel_name] = (VxlanTunnel_T)tnlptr;
@@ -344,6 +349,11 @@ public:
         {
             return 0;
         }
+    }
+
+    auto getVniVlanMapTableSize()
+    {
+        return vxlan_vni_vlan_map_table_.size();
     }
 
     void addVlanMappedToVni(uint32_t vni, uint16_t vlan_id)
@@ -541,6 +551,11 @@ public:
     VxlanTunnel* getEVPNVtep() 
     { 
         return source_vtep_ptr;
+    }
+
+    void delEVPNVtep()
+    {
+        source_vtep_ptr = NULL;
     }
 
 private:


### PR DESCRIPTION
This patch adds multiple protections to prevent invalid memory access and ensure the correct removal order of VTEPs and related resources:

1. Fix EVPN orch accessing invalid memory EVPN orch stores a private pointer to the local VTEP, which is managed by the VxLAN tunnel orch. When the VxLAN tunnel orch removes the local VTEP, it does not notify EVPN orch, leading to potential use-after-free issues. This patch adds protection to avoid accessing invalid addresses.

2. Ensure local VTEP is the last tunnel removed Adds a check to guarantee that the local VTEP is removed only after all user tunnels. EVPN orch also relies on this behavior to avoid processing errors due to unexpected tunnel removal order.

3. Check VLAN-VNI map before removing local VTEP Adds a validation step to ensure the VLAN-VNI map is cleared before removing the local VTEP. This prevents premature deletion of shared resources that may still be in use by user-defined tunnels.