### PR TITLE
Increase the FPM message maximum size to allow 256 ecmp group members

### DIFF
--- a/fpmsyncd/fpm/fpm.h
+++ b/fpmsyncd/fpm/fpm.h
@@ -91,8 +91,10 @@
 
 /*
  * Largest message that can be sent to or received from the FPM.
+ * The maximum length of a message that can be sent to or received from the FPM.
+ * This defines the upper limit on the size of nexthop groups that the FPM can handle.
  */
-#define FPM_MAX_MSG_LEN 4096
+#define FPM_MAX_MSG_LEN 8192
 
 /*
  * Header that precedes each fpm message to/from the FPM.


### PR DESCRIPTION
Increase the FPM message maximum size to allow 256 ecmp group members

**Why I did it**
The ecmp group members can not reach 253 members and cause the message
`bgp#fpmsyncd: :- poll_descriptors: readData error: Malformed FPM message received: Bad message`

**How I verified it**
Add static route entry with 256 members

**Details if related**
