### PR TITLE
Support to configure slowpath MTU for Port

### DIFF
--- a/cfgmgr/portmgr.cpp
+++ b/cfgmgr/portmgr.cpp
@@ -50,8 +50,56 @@ bool PortMgr::setPortMtu(const string &alias, const string &mtu)
     {
         throw runtime_error(cmd_str + " : " + res);
     }
+    vector<FieldValueTuple> temp;
+
+    /* 'mtu_slowpath' has higher priority than 'mtu' for the netdev mtu in kernel */
+    if (m_cfgPortTable.get(alias, temp))
+    {
+        auto mtu_slowpath = swss::fvsGetValue(temp, "mtu_slowpath", true);
+        if (!mtu_slowpath)
+        {
+            // ip link set dev <port_name> mtu <mtu>
+            cmd << IP_CMD << " link set dev " << shellquote(alias) << " mtu " << shellquote(mtu);
+            EXEC_WITH_ERROR_THROW(cmd.str(), res);
+
+        }
+    }
+
+    // Set the port MTU in application database to update both
+    // the port MTU and possibly the port based router interface MTU
+    vector<FieldValueTuple> fvs;
+    FieldValueTuple fv("mtu", mtu);
+    fvs.push_back(fv);
+    m_appPortTable.set(alias, fvs);
+
     return true;
 }
+
+bool PortMgr::setPortMtuSlowpath(const string &alias, const string &mtu_slowpath)
+{
+    /* 'mtu_slowpath' will only configure the netdev mtu in kernel, and has higher priority than 'mtu' attr
+     */
+    stringstream cmd;
+    string res;
+    int ret;
+
+    SWSS_LOG_NOTICE("set mtu_slowpath netdev %s %s",
+                        alias.c_str(), mtu_slowpath.c_str());
+
+    // ip link set dev <port_name> mtu <mtu>
+    cmd << IP_CMD << " link set dev " << shellquote(alias) << " mtu " << shellquote(mtu_slowpath);
+    ret = swss::exec(cmd.str(), res);
+
+    if (ret)
+    {
+        SWSS_LOG_WARN("Failed to set mtu_slowpath to %s netdev with cmd:%s, rc:%d, error:%s",
+                        alias.c_str(), cmd.str().c_str(), ret, res.c_str());
+    }
+
+    return (ret == 0);
+}
+
+
 
 bool PortMgr::setPortAdminStatus(const string &alias, const bool up)
 {
@@ -190,6 +238,7 @@ void PortMgr::doTask(Consumer &consumer)
 
             string admin_status, mtu;
             std::vector<FieldValueTuple> field_values;
+            string mtu_slowpath = "";
 
             bool configured = (m_portList.find(alias) != m_portList.end());
 
@@ -218,6 +267,10 @@ void PortMgr::doTask(Consumer &consumer)
                 else if (fvField(i) == "admin_status")
                 {
                     admin_status = fvValue(i);
+                }
+                else if (fvField(i) == "mtu_slowpath")
+                {
+                    mtu_slowpath = fvValue(i);
                 }
                 else
                 {
@@ -249,6 +302,12 @@ void PortMgr::doTask(Consumer &consumer)
             {
                 setPortMtu(alias, mtu);
                 SWSS_LOG_NOTICE("Configure %s MTU to %s", alias.c_str(), mtu.c_str());
+            }
+
+            if (!mtu_slowpath.empty())
+            {
+                setPortMtuSlowpath(alias, mtu_slowpath);
+                SWSS_LOG_NOTICE("Configure %s slowpath MTU to %s", alias.c_str(), mtu_slowpath.c_str());
             }
 
             if (!admin_status.empty())

--- a/cfgmgr/portmgr.h
+++ b/cfgmgr/portmgr.h
@@ -40,6 +40,7 @@ private:
     bool setPortAdminStatus(const std::string &alias, const bool up);
     bool isPortStateOk(const std::string &alias);
     void setIntfIp2me(const std::string &alias, const std::string &opCmd, const IpPrefix &ipPrefix, const std::string &vrfName);
+    bool setPortMtuSlowpath(const std::string &alias, const std::string &mtu_slowpath);
 };
 
 }


### PR DESCRIPTION
Support slowpath MTU which will change netdev mtu in kernel only.

Why I did it
Support to chang netdev mtu in kernel only

How I did it
a new attribute for port in db: "mtu_slowpath"
'mtu_slowpath' has higher priority than 'mtu' for the netdev mtu in kernel
If slowpath MTU is specified, change netdev mtu in kernel

How I verified it
Change mtu for port to 9100
Change mtu_slowpath for port to 1500
Check "MTU" in "show interface status Ethernet0" should be 9100
Check 'mtu" in "ip link show Ethernet0" should be 1500