### PR TITLE
fix repeated warning message of PFC counter modification

### DIFF
--- a/orchagent/countercheckorch.cpp
+++ b/orchagent/countercheckorch.cpp
@@ -122,7 +122,7 @@ void CounterCheckOrch::pfcFrameCounterCheck()
         for (size_t prio = 0; prio != counters.size(); prio++)
         {
             bool isLossy = ((1 << prio) & pfcMask) == 0;
-            if (newCounters[prio] == numeric_limits<uint64_t>::max())
+            if (!isLossy && newCounters[prio] == numeric_limits<uint64_t>::max())
             {
                 SWSS_LOG_WARN("Could not retreive PFC frame count on queue %zu port %s",
                         prio,


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
check pfc status to avoid warning messages

**Why I did it**
On AS4630-54TE, its PFC counters can't be retrieved, so the warning message shows repeatedly.
This patch is to make the warning message only display when PFC enabled and PFC counters can't be retrieved.

**How I verified it**
The warning message will no longer show.


**Details if related**
