### PR TITLE
Restore flushFDBEntries operation mistakenly removed in previous commit

### DIFF
--- a/orchagent/fdborch.cpp
+++ b/orchagent/fdborch.cpp
@@ -1359,6 +1359,9 @@ void FdbOrch::updatePortOperState(const PortOperStateUpdate& update)
     {
         swss::Port p = update.port;
 
+        if (p.m_bridge_port_id != SAI_NULL_OBJECT_ID)
+            flushFDBEntries(p.m_bridge_port_id, SAI_NULL_OBJECT_ID);
+
         if (gMlagOrch->isIslInterface(update.port.m_alias) || gMlagOrch->isMlagInterface(update.port.m_alias))
         {
             SWSS_LOG_NOTICE("MCLAG member or peerlink change to down!");


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Restore code mistakenly deleted in previous commit
https://github.com/edge-core/sonic-swss/pull/70
**Why I did it**
n/a
**How I verified it**
n/a
**Details if related**
n/a