### PR TITLE
[MCLAG][SAG] Add SAG's MAC to fdb to prevent kernel flooding

### DIFF
--- a/cfgmgr/intfmgr.cpp
+++ b/cfgmgr/intfmgr.cpp
@@ -182,6 +182,36 @@ void IntfMgr::setIntfMac(const string &alias, const string &mac_str)
     }
 }
 
+void IntfMgr::addFdbEntry(const std::string &alias, const string &macAddr)
+{
+    string vlanPrefix = VLAN_PREFIX;
+    string vlanId = alias.substr(alias.find(vlanPrefix) + vlanPrefix.length());
+    stringstream cmd;
+    string res;
+
+    // The mac may be learned from other device, if use fdb add will return file exist error
+    cmd << BRIDGE_CMD << " fdb replace " << shellquote(macAddr) << " dev Bridge vlan " << shellquote(vlanId);
+    int ret = swss::exec(cmd.str(), res);
+    if (ret)
+    {
+        SWSS_LOG_ERROR("Command '%s' failed with rc %d", cmd.str().c_str(), ret);
+    }
+}
+
+void IntfMgr::delFdbEntry(const std::string &alias, const string &macAddr)
+{
+    string vlanPrefix = VLAN_PREFIX;
+    string vlanId = alias.substr(alias.find(vlanPrefix) + vlanPrefix.length());
+    stringstream cmd;
+    string res;
+    cmd << BRIDGE_CMD << " fdb del " << shellquote(macAddr) << " dev Bridge vlan " << shellquote(vlanId);
+    int ret = swss::exec(cmd.str(), res);
+    if (ret)
+    {
+        SWSS_LOG_ERROR("Command '%s' failed with rc %d", cmd.str().c_str(), ret);
+    }
+}
+
 void IntfMgr::setIntfVrf(const string &alias, const string &vrfName)
 {
     stringstream cmd;
@@ -1077,7 +1107,8 @@ bool IntfMgr::doIntfGeneralTask(const vector<string>& keys,
                         setIntfMac(alias, gwmac);
 
                         setIntfState(alias, true);
-
+                        addFdbEntry(alias, gwmac);
+                        m_sagMac = MacAddress(gwmac);
                         FieldValueTuple fvTuple("mac_addr", gwmac);
                         data.push_back(fvTuple);
                     }
@@ -1087,7 +1118,10 @@ bool IntfMgr::doIntfGeneralTask(const vector<string>& keys,
                     setIntfState(alias, false);
                     setIntfMac(alias, gMacAddress.to_string());
                     setIntfState(alias, true);
-
+                    if (m_sagMac != gMacAddress)
+                    {
+                        delFdbEntry(alias, m_sagMac.to_string());
+                    }
                     FieldValueTuple fvTuple("mac_addr", MacAddress().to_string());
                     data.push_back(fvTuple);
                 } else {
@@ -1471,8 +1505,13 @@ void IntfMgr::updateSagMac(const std::string &macAddr)
                 if (macAddr != gMacAddress.to_string())
                 {
                     entryMac = macAddr;
+                    addFdbEntry(key, macAddr);
                 }
-
+                else
+                {
+                    delFdbEntry(key, m_sagMac.to_string());
+                }
+                m_sagMac = MacAddress(macAddr);
                 FieldValueTuple fvTuple("mac_addr", entryMac);
                 vlanIntFv.push_back(fvTuple);
                 m_appIntfTableProducer.set(key, vlanIntFv);

--- a/cfgmgr/intfmgr.h
+++ b/cfgmgr/intfmgr.h
@@ -43,10 +43,13 @@ private:
     std::set<std::string> m_pendingReplayIntfList;
     std::set<std::string> m_ipv6LinkLocalModeList;
     std::string mySwitchType;
+    MacAddress m_sagMac;
 
     void setIntfIp(const std::string &alias, const std::string &opCmd, const IpPrefix &ipPrefix);
     void setIntfVrf(const std::string &alias, const std::string &vrfName);
     void setIntfMac(const std::string &alias, const std::string &macAddr);
+    void addFdbEntry(const std::string &alias, const std::string &macAddr);
+    void delFdbEntry(const std::string &alias, const std::string &macAddr);
     bool setIntfMpls(const std::string &alias, const std::string &mpls);
     void setIntfIp2me(const std::string &alias, const std::string &opCmd, const IpPrefix &ipPrefix, const std::string &vrfName);
     void setIntfState(const std::string &alias, bool isUp);

--- a/tests/test_sag.py
+++ b/tests/test_sag.py
@@ -82,6 +82,14 @@ class TestSag(object):
         assert exit_code == 0
         assert mac in result
 
+    def check_kernel_fdb(self, dvs, mac, vlan, exist):
+        (exit_code, result) = dvs.runcmd(['sh', '-c', "bridge fdb show vlan {}".format(vlan)])
+        assert exit_code == 0
+        if exist:
+            assert mac in result
+        else:
+            assert mac not in result
+
     def check_kernel_intf_ipv6_addr(self, dvs, interface, addr):
         (exit_code, result) = dvs.runcmd(["sh", "-c", "ip -6 address show {}".format(interface)])
         assert exit_code == 0
@@ -158,6 +166,7 @@ class TestSag(object):
 
         self.check_app_db_intf(fvs, mac, "true")
         self.check_kernel_intf_mac(dvs, vlan_intf, mac)
+        self.check_kernel_fdb(dvs, mac, vlan, True)
 
         ipv6_ll = self.generate_ipv6_link_local_addr(mac, 64)
         self.check_kernel_intf_ipv6_addr(dvs, vlan_intf, str(ipv6_ll))
@@ -173,6 +182,7 @@ class TestSag(object):
 
         self.check_app_db_intf(fvs, default_mac, "false")
         self.check_kernel_intf_mac(dvs, vlan_intf, system_mac)
+        self.check_kernel_fdb(dvs, mac, vlan, False)
 
         ipv6_ll = self.generate_ipv6_link_local_addr(system_mac, 64)
         self.check_kernel_intf_ipv6_addr(dvs, vlan_intf, str(ipv6_ll))
@@ -224,6 +234,7 @@ class TestSag(object):
 
         self.check_app_db_intf(fvs, mac, "true")
         self.check_kernel_intf_mac(dvs, vlan_intf, mac)
+        self.check_kernel_fdb(dvs, mac, vlan, True)
 
         ipv6_ll = self.generate_ipv6_link_local_addr(mac, 64)
         self.check_kernel_intf_ipv6_addr(dvs, vlan_intf, str(ipv6_ll))
@@ -244,6 +255,7 @@ class TestSag(object):
 
         self.check_app_db_intf(fvs, default_mac, "true")
         self.check_kernel_intf_mac(dvs, vlan_intf, system_mac)
+        self.check_kernel_fdb(dvs, mac, vlan, False)
 
         ipv6_ll = self.generate_ipv6_link_local_addr(system_mac, 64)
         self.check_kernel_intf_ipv6_addr(dvs, vlan_intf, str(ipv6_ll))
@@ -294,6 +306,7 @@ class TestSag(object):
 
         self.check_app_db_intf(fvs, mac, "true")
         self.check_kernel_intf_mac(dvs, vlan_intf, mac)
+        self.check_kernel_fdb(dvs, mac, vlan, True)
 
         ipv6_ll = self.generate_ipv6_link_local_addr(mac, 64)
         self.check_kernel_intf_ipv6_addr(dvs, vlan_intf, str(ipv6_ll))
@@ -309,6 +322,7 @@ class TestSag(object):
 
         self.check_app_db_intf(fvs, default_mac, "false")
         self.check_kernel_intf_mac(dvs, vlan_intf, system_mac)
+        self.check_kernel_fdb(dvs, mac, vlan, False)
 
         ipv6_ll = self.generate_ipv6_link_local_addr(system_mac, 64)
         self.check_kernel_intf_ipv6_addr(dvs, vlan_intf, str(ipv6_ll))


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Add SAG's MAC to fdb to prevent kernel flooding.

**Why I did it**
In MCLAG scenario, it will configure the same SAG MAC addresss.
When one peer receives another peer's packet which source MAC is SAG, kernel will also flood it, this will cause packet duplicated.
Add SAG's MAC to bridge can prevent this flooding.

**How I verified it**
N/A

**Details if related**
N/A