### PR TITLE
[Buffer] unicast queue counter disappear after performing "qos clear" command.

### DIFF
--- a/orchagent/bufferorch.cpp
+++ b/orchagent/bufferorch.cpp
@@ -1,6 +1,5 @@
 #include "tokenize.h"
 #include "bufferorch.h"
-#include "directory.h"
 #include "logger.h"
 #include "sai_serialize.h"
 #include "warm_restart.h"
@@ -17,7 +16,6 @@ extern sai_switch_api_t *sai_switch_api;
 extern sai_buffer_api_t *sai_buffer_api;
 
 extern PortsOrch *gPortsOrch;
-extern Directory<Orch*> gDirectory;
 extern sai_object_id_t gSwitchId;
 extern string gMySwitchType;
 extern string gMyHostName;
@@ -1036,22 +1034,6 @@ task_process_status BufferOrch::processQueue(KeyOpFieldsValuesTuple &tuple)
                         return handle_status;
                     }
                 }
-                // create/remove a port queue counter for the queue buffer
-                else
-                {
-                    auto flexCounterOrch = gDirectory.get<FlexCounterOrch*>();
-                    auto queues = tokens[1];
-                    if (op == SET_COMMAND &&
-                        (flexCounterOrch->getQueueCountersState() || flexCounterOrch->getQueueWatermarkCountersState()))
-                    {
-                        gPortsOrch->createPortBufferQueueCounters(port, queues);
-                    }
-                    else if (op == DEL_COMMAND &&
-                             (flexCounterOrch->getQueueCountersState() || flexCounterOrch->getQueueWatermarkCountersState()))
-                    {
-                        gPortsOrch->removePortBufferQueueCounters(port, queues);
-                    }
-                }
             }
 
             /* when we apply buffer configuration we need to increase the ref counter of this port
@@ -1062,23 +1044,23 @@ task_process_status BufferOrch::processQueue(KeyOpFieldsValuesTuple &tuple)
              * so we added a map that will help us to know what was the last command for this port and priority -
              * if the last command was set command then it is a modify command and we dont need to increase the buffer counter
              * all other cases (no last command exist or del command was the last command) it means that we need to increase the ref counter */
-            if (op == SET_COMMAND)
+            if (op == SET_COMMAND) 
             {
-                if (queue_port_flags[port_name][ind] != SET_COMMAND)
+                if (queue_port_flags[port_name][ind] != SET_COMMAND) 
                 {
                     /* if the last operation was not "set" then it's create and not modify - need to increase ref counter */
                     gPortsOrch->increasePortRefCount(port_name);
                 }
-            }
+            } 
             else if (op == DEL_COMMAND)
             {
-                if (queue_port_flags[port_name][ind] == SET_COMMAND)
+                if (queue_port_flags[port_name][ind] == SET_COMMAND) 
 		{
                     /* we need to decrease ref counter only if the last operation was "SET_COMMAND" */
                     gPortsOrch->decreasePortRefCount(port_name);
                 }
-            }
-            else
+            } 
+            else 
             {
                 SWSS_LOG_ERROR("operation value is not SET or DEL (op = %s)", op.c_str());
                 return task_process_status::task_invalid_entry;
@@ -1154,7 +1136,7 @@ task_process_status BufferOrch::processPriorityGroup(KeyOpFieldsValuesTuple &tup
     if (op == SET_COMMAND)
     {
         ref_resolve_status  resolve_result = resolveFieldRefValue(m_buffer_type_maps, buffer_profile_field_name,
-                                             buffer_to_ref_table_map.at(buffer_profile_field_name), tuple,
+                                             buffer_to_ref_table_map.at(buffer_profile_field_name), tuple, 
                                              sai_buffer_profile, buffer_profile_name);
         if (ref_resolve_status::success != resolve_result)
         {
@@ -1235,22 +1217,6 @@ task_process_status BufferOrch::processPriorityGroup(KeyOpFieldsValuesTuple &tup
                             return handle_status;
                         }
                     }
-                    // create or remove a port PG counter for the PG buffer
-                    else
-                    {
-                        auto flexCounterOrch = gDirectory.get<FlexCounterOrch*>();
-                        auto pgs = tokens[1];
-                        if (op == SET_COMMAND &&
-                            (flexCounterOrch->getPgCountersState() || flexCounterOrch->getPgWatermarkCountersState()))
-                        {
-                            gPortsOrch->createPortBufferPgCounters(port, pgs);
-                        }
-                        else if (op == DEL_COMMAND &&
-                                 (flexCounterOrch->getPgCountersState() || flexCounterOrch->getPgWatermarkCountersState()))
-                        {
-                            gPortsOrch->removePortBufferPgCounters(port, pgs);
-                        }
-                    }
                 }
             }
 
@@ -1262,23 +1228,23 @@ task_process_status BufferOrch::processPriorityGroup(KeyOpFieldsValuesTuple &tup
              * so we added a map that will help us to know what was the last command for this port and priority -
              * if the last command was set command then it is a modify command and we dont need to increase the buffer counter
              * all other cases (no last command exist or del command was the last command) it means that we need to increase the ref counter */
-            if (op == SET_COMMAND)
+            if (op == SET_COMMAND) 
             {
-                if (pg_port_flags[port_name][ind] != SET_COMMAND)
+                if (pg_port_flags[port_name][ind] != SET_COMMAND) 
                 {
                     /* if the last operation was not "set" then it's create and not modify - need to increase ref counter */
                     gPortsOrch->increasePortRefCount(port_name);
                 }
-            }
+            } 
             else if (op == DEL_COMMAND)
             {
-                if (pg_port_flags[port_name][ind] == SET_COMMAND)
+                if (pg_port_flags[port_name][ind] == SET_COMMAND) 
                 {
                     /* we need to decrease ref counter only if the last operation was "SET_COMMAND" */
                     gPortsOrch->decreasePortRefCount(port_name);
                 }
-            }
-            else
+            } 
+            else 
             {
                 SWSS_LOG_ERROR("operation value is not SET or DEL (op = %s)", op.c_str());
                 return task_process_status::task_invalid_entry;

--- a/orchagent/flexcounterorch.cpp
+++ b/orchagent/flexcounterorch.cpp
@@ -10,7 +10,6 @@
 #include "debugcounterorch.h"
 #include "directory.h"
 #include "copporch.h"
-#include <swss/tokenize.h>
 #include "routeorch.h"
 #include "macsecorch.h"
 #include "flowcounterrouteorch.h"
@@ -29,9 +28,7 @@ extern FlowCounterRouteOrch *gFlowCounterRouteOrch;
 #define PORT_KEY                    "PORT"
 #define PORT_BUFFER_DROP_KEY        "PORT_BUFFER_DROP"
 #define QUEUE_KEY                   "QUEUE"
-#define QUEUE_WATERMARK             "QUEUE_WATERMARK"
 #define PG_WATERMARK_KEY            "PG_WATERMARK"
-#define PG_DROP_KEY                 "PG_DROP"
 #define RIF_KEY                     "RIF"
 #define ACL_KEY                     "ACL"
 #define TUNNEL_KEY                  "TUNNEL"
@@ -65,9 +62,6 @@ unordered_map<string, string> flexCounterGroupMap =
 FlexCounterOrch::FlexCounterOrch(DBConnector *db, vector<string> &tableNames):
     Orch(db, tableNames),
     m_flexCounterConfigTable(db, CFG_FLEX_COUNTER_TABLE_NAME),
-    m_bufferQueueConfigTable(db, CFG_BUFFER_QUEUE_TABLE_NAME),
-    m_bufferPgConfigTable(db, CFG_BUFFER_PG_TABLE_NAME),
-    m_deviceMetadataConfigTable(db, CFG_DEVICE_METADATA_TABLE_NAME),
     m_flexCounterDb(new DBConnector("FLEX_COUNTER_DB", 0)),
     m_flexCounterGroupTable(new ProducerTable(m_flexCounterDb.get(), FLEX_COUNTER_GROUP_TABLE)),
     m_gbflexCounterDb(new DBConnector("GB_FLEX_COUNTER_DB", 0)),
@@ -163,27 +157,11 @@ void FlexCounterOrch::doTask(Consumer &consumer)
                         }
                         else if(key == QUEUE_KEY)
                         {
-                            gPortsOrch->generateQueueMap(getQueueConfigurations());
-                            m_queue_enabled = true;
-                            gPortsOrch->addQueueFlexCounters(getQueueConfigurations());
-                        }
-                        else if(key == QUEUE_WATERMARK)
-                        {
-                            gPortsOrch->generateQueueMap(getQueueConfigurations());
-                            m_queue_watermark_enabled = true;
-                            gPortsOrch->addQueueWatermarkFlexCounters(getQueueConfigurations());
-                        }
-                        else if(key == PG_DROP_KEY)
-                        {
-                            gPortsOrch->generatePriorityGroupMap(getPgConfigurations());
-                            m_pg_enabled = true;
-                            gPortsOrch->addPriorityGroupFlexCounters(getPgConfigurations());
+                            gPortsOrch->generateQueueMap();
                         }
                         else if(key == PG_WATERMARK_KEY)
                         {
-                            gPortsOrch->generatePriorityGroupMap(getPgConfigurations());
-                            m_pg_watermark_enabled = true;
-                            gPortsOrch->addPriorityGroupWatermarkFlexCounters(getPgConfigurations());
+                            gPortsOrch->generatePriorityGroupMap();
                         }
                     }
                     if(gIntfsOrch && (key == RIF_KEY) && (value == "enable"))
@@ -267,26 +245,6 @@ bool FlexCounterOrch::getPortBufferDropCountersState() const
     return m_port_buffer_drop_counter_enabled;
 }
 
-bool FlexCounterOrch::getQueueCountersState() const
-{
-    return m_queue_enabled;
-}
-
-bool FlexCounterOrch::getQueueWatermarkCountersState() const
-{
-    return m_queue_watermark_enabled;
-}
-
-bool FlexCounterOrch::getPgCountersState() const
-{
-    return m_pg_enabled;
-}
-
-bool FlexCounterOrch::getPgWatermarkCountersState() const
-{
-    return m_pg_watermark_enabled;
-}
-
 bool FlexCounterOrch::bake()
 {
     /*
@@ -327,204 +285,4 @@ bool FlexCounterOrch::bake()
     }
     Consumer* consumer = dynamic_cast<Consumer *>(getExecutor(CFG_FLEX_COUNTER_TABLE_NAME));
     return consumer->addToSync(entries);
-}
-
-static bool isCreateOnlyConfigDbBuffers(Table& deviceMetadataConfigTable)
-{
-    std::string createOnlyConfigDbBuffersValue;
-
-    try
-    {
-        if (deviceMetadataConfigTable.hget("localhost", "create_only_config_db_buffers", createOnlyConfigDbBuffersValue))
-        {
-            if (createOnlyConfigDbBuffersValue == "true")
-            {
-                return true;
-            }
-        }
-    }
-    catch(const std::system_error& e)
-    {
-        SWSS_LOG_ERROR("System error: %s", e.what());
-    }
-
-    return false;
-}
-
-map<string, FlexCounterQueueStates> FlexCounterOrch::getQueueConfigurations()
-{
-    SWSS_LOG_ENTER();
-
-    map<string, FlexCounterQueueStates> queuesStateVector;
-
-    if (!isCreateOnlyConfigDbBuffers(m_deviceMetadataConfigTable))
-    {
-        FlexCounterQueueStates flexCounterQueueState(0);
-        queuesStateVector.insert(make_pair(createAllAvailableBuffersStr, flexCounterQueueState));
-        return queuesStateVector;
-    }
-
-    std::vector<std::string> portQueueKeys;
-    m_bufferQueueConfigTable.getKeys(portQueueKeys);
-
-    for (const auto& portQueueKey : portQueueKeys)
-    {
-        auto toks = tokenize(portQueueKey, '|');
-        if (toks.size() != 2)
-        {
-            SWSS_LOG_ERROR("Invalid BUFFER_QUEUE key: [%s]", portQueueKey.c_str());
-            continue;
-        }
-
-        auto configPortNames = tokenize(toks[0], ',');
-        auto configPortQueues = toks[1];
-        toks = tokenize(configPortQueues, '-');
-
-        for (const auto& configPortName : configPortNames)
-        {
-            uint32_t maxQueueNumber = gPortsOrch->getNumberOfPortSupportedQueueCounters(configPortName);
-            uint32_t maxQueueIndex = maxQueueNumber - 1;
-            uint32_t minQueueIndex = 0;
-
-            if (!queuesStateVector.count(configPortName))
-            {
-                FlexCounterQueueStates flexCounterQueueState(maxQueueNumber);
-                queuesStateVector.insert(make_pair(configPortName, flexCounterQueueState));
-            }
-
-            try {
-                auto startIndex = to_uint<uint32_t>(toks[0], minQueueIndex, maxQueueIndex);
-                if (toks.size() > 1)
-                {
-                    auto endIndex = to_uint<uint32_t>(toks[1], minQueueIndex, maxQueueIndex);
-                    queuesStateVector.at(configPortName).enableQueueCounters(startIndex, endIndex);
-                }
-                else
-                {
-                    queuesStateVector.at(configPortName).enableQueueCounter(startIndex);
-                }
-            } catch (std::invalid_argument const& e) {
-                    SWSS_LOG_ERROR("Invalid queue index [%s] for port [%s]", configPortQueues.c_str(), configPortName.c_str());
-                    continue;
-            }
-        }
-    }
-
-    return queuesStateVector;
-}
-
-map<string, FlexCounterPgStates> FlexCounterOrch::getPgConfigurations()
-{
-    SWSS_LOG_ENTER();
-
-    map<string, FlexCounterPgStates> pgsStateVector;
-
-    if (!isCreateOnlyConfigDbBuffers(m_deviceMetadataConfigTable))
-    {
-        FlexCounterPgStates flexCounterPgState(0);
-        pgsStateVector.insert(make_pair(createAllAvailableBuffersStr, flexCounterPgState));
-        return pgsStateVector;
-    }
-
-    std::vector<std::string> portPgKeys;
-    m_bufferPgConfigTable.getKeys(portPgKeys);
-
-    for (const auto& portPgKey : portPgKeys)
-    {
-        auto toks = tokenize(portPgKey, '|');
-        if (toks.size() != 2)
-        {
-            SWSS_LOG_ERROR("Invalid BUFFER_PG key: [%s]", portPgKey.c_str());
-            continue;
-        }
-
-        auto configPortNames = tokenize(toks[0], ',');
-        auto configPortPgs = toks[1];
-        toks = tokenize(configPortPgs, '-');
-
-        for (const auto& configPortName : configPortNames)
-        {
-            uint32_t maxPgNumber = gPortsOrch->getNumberOfPortSupportedPgCounters(configPortName);
-            uint32_t maxPgIndex = maxPgNumber - 1;
-            uint32_t minPgIndex = 0;
-
-            if (!pgsStateVector.count(configPortName))
-            {
-                FlexCounterPgStates flexCounterPgState(maxPgNumber);
-                pgsStateVector.insert(make_pair(configPortName, flexCounterPgState));
-            }
-
-            try {
-                auto startIndex = to_uint<uint32_t>(toks[0], minPgIndex, maxPgIndex);
-                if (toks.size() > 1)
-                {
-                    auto endIndex = to_uint<uint32_t>(toks[1], minPgIndex, maxPgIndex);
-                    pgsStateVector.at(configPortName).enablePgCounters(startIndex, endIndex);
-                }
-                else
-                {
-                    pgsStateVector.at(configPortName).enablePgCounter(startIndex);
-                }
-            } catch (std::invalid_argument const& e) {
-                    SWSS_LOG_ERROR("Invalid pg index [%s] for port [%s]", configPortPgs.c_str(), configPortName.c_str());
-                    continue;
-            }
-        }
-    }
-
-    return pgsStateVector;
-}
-
-FlexCounterQueueStates::FlexCounterQueueStates(uint32_t maxQueueNumber)
-{
-    SWSS_LOG_ENTER();
-    m_queueStates.resize(maxQueueNumber, false);
-}
-
-bool FlexCounterQueueStates::isQueueCounterEnabled(uint32_t index) const
-{
-    SWSS_LOG_ENTER();
-    return m_queueStates[index];
-}
-
-void FlexCounterQueueStates::enableQueueCounters(uint32_t startIndex, uint32_t endIndex)
-{
-    SWSS_LOG_ENTER();
-    for (uint32_t queueIndex = startIndex; queueIndex <= endIndex; queueIndex++)
-    {
-        enableQueueCounter(queueIndex);
-    }
-}
-
-void FlexCounterQueueStates::enableQueueCounter(uint32_t queueIndex)
-{
-    SWSS_LOG_ENTER();
-    m_queueStates[queueIndex] = true;
-}
-
-FlexCounterPgStates::FlexCounterPgStates(uint32_t maxPgNumber)
-{
-    SWSS_LOG_ENTER();
-    m_pgStates.resize(maxPgNumber, false);
-}
-
-bool FlexCounterPgStates::isPgCounterEnabled(uint32_t index) const
-{
-    SWSS_LOG_ENTER();
-    return m_pgStates[index];
-}
-
-void FlexCounterPgStates::enablePgCounters(uint32_t startIndex, uint32_t endIndex)
-{
-    SWSS_LOG_ENTER();
-    for (uint32_t pgIndex = startIndex; pgIndex <= endIndex; pgIndex++)
-    {
-        enablePgCounter(pgIndex);
-    }
-}
-
-void FlexCounterPgStates::enablePgCounter(uint32_t pgIndex)
-{
-    SWSS_LOG_ENTER();
-    m_pgStates[pgIndex] = true;
 }

--- a/orchagent/flexcounterorch.h
+++ b/orchagent/flexcounterorch.h
@@ -10,32 +10,6 @@ extern "C" {
 #include "sai.h"
 }
 
-const std::string createAllAvailableBuffersStr = "create_all_available_buffers";
-
-class FlexCounterQueueStates
-{
-public:
-    FlexCounterQueueStates(uint32_t maxQueueNumber);
-    bool isQueueCounterEnabled(uint32_t index) const;
-    void enableQueueCounters(uint32_t startIndex, uint32_t endIndex);
-    void enableQueueCounter(uint32_t queueIndex);
-
-private:
-    std::vector<bool> m_queueStates{};
-};
-
-class FlexCounterPgStates
-{
-public:
-    FlexCounterPgStates(uint32_t maxPgNumber);
-    bool isPgCounterEnabled(uint32_t index) const;
-    void enablePgCounters(uint32_t startIndex, uint32_t endIndex);
-    void enablePgCounter(uint32_t pgIndex);
-
-private:
-    std::vector<bool> m_pgStates{};
-};
-
 class FlexCounterOrch: public Orch
 {
 public:
@@ -44,12 +18,6 @@ public:
     virtual ~FlexCounterOrch(void);
     bool getPortCountersState() const;
     bool getPortBufferDropCountersState() const;
-    bool getQueueCountersState() const;
-    bool getQueueWatermarkCountersState() const;
-    bool getPgCountersState() const;
-    bool getPgWatermarkCountersState() const;
-    std::map<std::string, FlexCounterQueueStates> getQueueConfigurations();
-    std::map<std::string, FlexCounterPgStates> getPgConfigurations();
     bool getHostIfTrapCounterState() const {return m_hostif_trap_counter_enabled;}
     bool getRouteFlowCountersState() const {return m_route_flow_counter_enabled;}
     bool bake() override;
@@ -61,16 +29,9 @@ private:
     std::shared_ptr<ProducerTable> m_gbflexCounterGroupTable = nullptr;
     bool m_port_counter_enabled = false;
     bool m_port_buffer_drop_counter_enabled = false;
-    bool m_queue_enabled = false;
-    bool m_queue_watermark_enabled = false;
-    bool m_pg_enabled = false;
-    bool m_pg_watermark_enabled = false;
     bool m_hostif_trap_counter_enabled = false;
     bool m_route_flow_counter_enabled = false;
     Table m_flexCounterConfigTable;
-    Table m_bufferQueueConfigTable;
-    Table m_bufferPgConfigTable;
-    Table m_deviceMetadataConfigTable;
 };
 
 #endif

--- a/orchagent/p4orch/tests/fake_flexcounterorch.cpp
+++ b/orchagent/p4orch/tests/fake_flexcounterorch.cpp
@@ -1,12 +1,8 @@
 #include "copporch.h"
 #include "flexcounterorch.h"
 
-FlexCounterOrch::FlexCounterOrch(swss::DBConnector *db, std::vector<std::string> &tableNames) :
-    Orch(db, tableNames),
-    m_flexCounterConfigTable(db, CFG_FLEX_COUNTER_TABLE_NAME),
-    m_bufferQueueConfigTable(db, CFG_BUFFER_QUEUE_TABLE_NAME),
-    m_bufferPgConfigTable(db, CFG_BUFFER_PG_TABLE_NAME),
-    m_deviceMetadataConfigTable(db, CFG_DEVICE_METADATA_TABLE_NAME)
+FlexCounterOrch::FlexCounterOrch(swss::DBConnector *db, std::vector<std::string> &tableNames)
+    : Orch(db, tableNames), m_flexCounterConfigTable(db, CFG_FLEX_COUNTER_TABLE_NAME)
 {
 }
 

--- a/orchagent/p4orch/tests/fake_portorch.cpp
+++ b/orchagent/p4orch/tests/fake_portorch.cpp
@@ -181,35 +181,11 @@ bool PortsOrch::setPortPfc(sai_object_id_t portId, uint8_t pfc_bitmask)
     return true;
 }
 
-void PortsOrch::generateQueueMap(std::map<string, FlexCounterQueueStates> queuesStateVector)
+void PortsOrch::generateQueueMap()
 {
 }
 
-void PortsOrch::generateQueueMapPerPort(const Port& port, FlexCounterQueueStates& queuesState, bool voq)
-{
-}
-
-void PortsOrch::createPortBufferQueueCounters(const Port &port, string queues)
-{
-}
-
-void PortsOrch::removePortBufferQueueCounters(const Port &port, string queues)
-{
-}
-
-void PortsOrch::generatePriorityGroupMap(std::map<string, FlexCounterPgStates> pgsStateVector)
-{
-}
-
-void PortsOrch::generatePriorityGroupMapPerPort(const Port& port, FlexCounterPgStates& pgsState)
-{
-}
-
-void PortsOrch::createPortBufferPgCounters(const Port& port, string pgs)
-{
-}
-
-void PortsOrch::removePortBufferPgCounters(const Port& port, string pgs)
+void PortsOrch::generatePriorityGroupMap()
 {
 }
 
@@ -601,7 +577,15 @@ bool PortsOrch::getQueueTypeAndIndex(sai_object_id_t queue_id, string &type, uin
     return true;
 }
 
-bool PortsOrch::isAutoNegEnabled(sai_object_id_t id)
+void PortsOrch::generateQueueMapPerPort(const Port &port, bool voq)
+{
+}
+
+void PortsOrch::generatePriorityGroupMapPerPort(const Port &port)
+{
+}
+
+task_process_status PortsOrch::setPortAutoNeg(sai_object_id_t id, int an)
 {
     return true;
 }

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -3242,6 +3242,18 @@ bool PortsOrch::initPort(const PortConfig &port)
                     port_buffer_drop_stat_manager.setCounterIdList(p.m_port_id, CounterType::PORT, port_buffer_drop_stats);
                 }
 
+                /* when a port is added and priority group map counter is enabled --> we need to add pg counter for it */
+                if (m_isPriorityGroupMapGenerated)
+                {
+                    generatePriorityGroupMapPerPort(p);
+                }
+
+                /* when a port is added and queue map counter is enabled --> we need to add queue map counter for it */
+                if (m_isQueueMapGenerated)
+                {
+                    generateQueueMapPerPort(p, false);
+                }
+
                 PortUpdate update = { p, true };
                 notify(SUBJECT_TYPE_PORT_CHANGE, static_cast<void *>(&update));
 
@@ -3292,6 +3304,18 @@ void PortsOrch::deInitPort(string alias, sai_object_id_t port_id)
     if (flex_counters_orch->getPortBufferDropCountersState())
     {
         port_buffer_drop_stat_manager.clearCounterIdList(p.m_port_id);
+    }
+
+    /* remove pg port counters */
+    if (m_isPriorityGroupMapGenerated)
+    {
+        removePriorityGroupMapPerPort(p);
+    }
+
+    /* remove queue port counters */
+    if (m_isQueueMapGenerated)
+    {
+        removeQueueMapPerPort(p);
     }
 
     /* remove port name map from counter table */
@@ -6978,66 +7002,81 @@ bool PortsOrch::removeTunnel(Port tunnel)
     return true;
 }
 
-void PortsOrch::generateQueueMap(map<string, FlexCounterQueueStates> queuesStateVector)
+void PortsOrch::generateQueueMap()
 {
     if (m_isQueueMapGenerated)
     {
         return;
     }
 
-    bool isCreateAllQueues = false;
-
-    if (queuesStateVector.count(createAllAvailableBuffersStr))
-    {
-        isCreateAllQueues = true;
-        queuesStateVector.clear();
-    }
-
     for (const auto& it: m_portList)
     {
-        if (it.second.m_type == Port::PHY)
+        if (it.second.m_type == Port::PHY ||
+            it.second.m_type == Port::CPU)
         {
-            if (!queuesStateVector.count(it.second.m_alias))
-            {
-                auto maxQueueNumber = getNumberOfPortSupportedQueueCounters(it.second.m_alias);
-                FlexCounterQueueStates flexCounterQueueState(maxQueueNumber);
-                if (isCreateAllQueues && maxQueueNumber)
-                {
-                    flexCounterQueueState.enableQueueCounters(0, maxQueueNumber - 1);
-                }
-                queuesStateVector.insert(make_pair(it.second.m_alias, flexCounterQueueState));
-            }
-            generateQueueMapPerPort(it.second, queuesStateVector.at(it.second.m_alias), false);
+            generateQueueMapPerPort(it.second, false);
             if (gMySwitchType == "voq")
             {
-                generateQueueMapPerPort(it.second, queuesStateVector.at(it.second.m_alias), true);
+               generateQueueMapPerPort(it.second, true);
             }
         }
 
         if (it.second.m_type == Port::SYSTEM)
         {
-            if (!queuesStateVector.count(it.second.m_alias))
-            {
-                auto maxQueueNumber = getNumberOfPortSupportedQueueCounters(it.second.m_alias);
-                FlexCounterQueueStates flexCounterQueueState(maxQueueNumber);
-                queuesStateVector.insert(make_pair(it.second.m_alias, flexCounterQueueState));
-            }
-            generateQueueMapPerPort(it.second, queuesStateVector.at(it.second.m_alias), true);
+           generateQueueMapPerPort(it.second, true);
         }
     }
 
     m_isQueueMapGenerated = true;
 }
 
-void PortsOrch::generateQueueMapPerPort(const Port& port, FlexCounterQueueStates& queuesState, bool voq)
+void PortsOrch::removeQueueMapPerPort(const Port& port)
+{
+    /* Remove the Queue map in the Counter DB */
+
+    for (size_t queueIndex = 0; queueIndex < port.m_queue_ids.size(); ++queueIndex)
+    {
+        std::ostringstream name;
+        name << port.m_alias << ":" << queueIndex;
+        std::unordered_set<string> counter_stats;
+
+        const auto id = sai_serialize_object_id(port.m_queue_ids[queueIndex]);
+
+        m_queueTable->hdel("",name.str());
+        m_queuePortTable->hdel("",id);
+
+        string queueType;
+        uint8_t queueRealIndex = 0;
+        if (getQueueTypeAndIndex(port.m_queue_ids[queueIndex], queueType, queueRealIndex))
+        {
+            m_queueTypeTable->hdel("",id);
+            m_queueIndexTable->hdel("",id);
+        }
+
+        for (const auto& it: queue_stat_ids)
+        {
+            counter_stats.emplace(sai_serialize_queue_stat(it));
+        }
+        queue_stat_manager.clearCounterIdList(port.m_queue_ids[queueIndex]);
+
+        /* remove watermark queue counters */
+        string key = getQueueWatermarkFlexCounterTableKey(id);
+
+        m_flexCounterTable->del(key);
+    }
+
+    CounterCheckOrch::getInstance().removePort(port);
+}
+
+void PortsOrch::generateQueueMapPerPort(const Port& port, bool voq)
 {
     /* Create the Queue map in the Counter DB */
+    /* Add stat counters to flex_counter */
     vector<FieldValueTuple> queueVector;
     vector<FieldValueTuple> queuePortVector;
     vector<FieldValueTuple> queueIndexVector;
     vector<FieldValueTuple> queueTypeVector;
     std::vector<sai_object_id_t> queue_ids;
-
     if (voq)
     {
         queue_ids = m_port_voq_ids[port.m_alias];
@@ -7050,55 +7089,62 @@ void PortsOrch::generateQueueMapPerPort(const Port& port, FlexCounterQueueStates
     for (size_t queueIndex = 0; queueIndex < queue_ids.size(); ++queueIndex)
     {
         std::ostringstream name;
-
-        if (voq)
-        {
+	if (voq)
+	{
             name << port.m_system_port_info.alias << ":" << queueIndex;
+	}
+	else
+	{
+            name << port.m_alias << ":" << queueIndex;
+	}
+
+        const auto id = sai_serialize_object_id(queue_ids[queueIndex]);
+
+        queueVector.emplace_back(name.str(), id);
+	if (voq)
+        {
+            queuePortVector.emplace_back(id, sai_serialize_object_id(port.m_system_port_oid));
         }
         else
         {
-            name << port.m_alias << ":" << queueIndex;
+            queuePortVector.emplace_back(id, sai_serialize_object_id(port.m_port_id));
         }
-
-        const auto id = sai_serialize_object_id(queue_ids[queueIndex]);
 
         string queueType;
         uint8_t queueRealIndex = 0;
         if (getQueueTypeAndIndex(queue_ids[queueIndex], queueType, queueRealIndex))
         {
-	    /* voq counters are always enabled. There is no mechanism to disable voq
-	     * counters in a voq system. */
-            if ((gMySwitchType != "voq")  && !queuesState.isQueueCounterEnabled(queueRealIndex))
-            {
-                continue;
-            }
             queueTypeVector.emplace_back(id, queueType);
             queueIndexVector.emplace_back(id, to_string(queueRealIndex));
         }
 
-        queueVector.emplace_back(name.str(), id);
-        if (voq)
+        // Install a flex counter for this queue to track stats
+        std::unordered_set<string> counter_stats;
+        for (const auto& it: queue_stat_ids)
         {
-            // Install a flex counter for this voq to track stats. Voq counters do
-            // not have buffer queue config. So it does not get enabled through the
-            // flexcounter orch logic. Always enabled voq counters.
-            addQueueFlexCountersPerPortPerQueueIndex(port, queueIndex, true);
-            queuePortVector.emplace_back(id, sai_serialize_object_id(port.m_system_port_oid));
+            counter_stats.emplace(sai_serialize_queue_stat(it));
         }
-        else
+        queue_stat_manager.setCounterIdList(queue_ids[queueIndex], CounterType::QUEUE, counter_stats);
+
+	if (voq) {
+	    continue;
+	}
+
+        /* add watermark queue counters */
+        string key = getQueueWatermarkFlexCounterTableKey(id);
+
+        string delimiter("");
+        std::ostringstream counters_stream;
+        for (const auto& it: queueWatermarkStatIds)
         {
-            // In voq systems, always install a flex counter for this egress queue
-            // to track stats. In voq systems, the buffer profiles are defined on
-            // sysports. So the phy ports do not have buffer queue config. Hence
-            // queuesStateVector built by getQueueConfigurations in flexcounterorch
-            // never has phy ports in voq systems. So always enabled egress queue
-            // counter on voq systems.
-            if (gMySwitchType == "voq")
-            {
-               addQueueFlexCountersPerPortPerQueueIndex(port, queueIndex, false);
-            }
-            queuePortVector.emplace_back(id, sai_serialize_object_id(port.m_port_id));
+            counters_stream << delimiter << sai_serialize_queue_stat(it);
+            delimiter = comma;
         }
+
+        vector<FieldValueTuple> fieldValues;
+        fieldValues.emplace_back(QUEUE_COUNTER_ID_LIST, counters_stream.str());
+
+        m_flexCounterTable->set(key, fieldValues);
     }
 
     if (voq)
@@ -7108,217 +7154,7 @@ void PortsOrch::generateQueueMapPerPort(const Port& port, FlexCounterQueueStates
     else
     {
         m_queueTable->set("", queueVector);
-        CounterCheckOrch::getInstance().addPort(port);
     }
-    m_queuePortTable->set("", queuePortVector);
-    m_queueIndexTable->set("", queueIndexVector);
-    m_queueTypeTable->set("", queueTypeVector);
-
-}
-
-void PortsOrch::addQueueFlexCounters(map<string, FlexCounterQueueStates> queuesStateVector)
-{
-    if (m_isQueueFlexCountersAdded)
-    {
-        return;
-    }
-
-    bool isCreateAllQueues = false;
-
-    if (queuesStateVector.count(createAllAvailableBuffersStr))
-    {
-        isCreateAllQueues = true;
-        queuesStateVector.clear();
-    }
-
-    for (const auto& it: m_portList)
-    {
-        if (it.second.m_type == Port::PHY)
-        {
-            if (!queuesStateVector.count(it.second.m_alias))
-            {
-                auto maxQueueNumber = getNumberOfPortSupportedQueueCounters(it.second.m_alias);
-                FlexCounterQueueStates flexCounterQueueState(maxQueueNumber);
-                if (isCreateAllQueues && maxQueueNumber)
-                {
-                    flexCounterQueueState.enableQueueCounters(0, maxQueueNumber - 1);
-                }
-                queuesStateVector.insert(make_pair(it.second.m_alias, flexCounterQueueState));
-            }
-            addQueueFlexCountersPerPort(it.second, queuesStateVector.at(it.second.m_alias));
-        }
-    }
-
-    m_isQueueFlexCountersAdded = true;
-}
-
-
-void PortsOrch::addQueueFlexCountersPerPort(const Port& port, FlexCounterQueueStates& queuesState)
-{
-    for (size_t queueIndex = 0; queueIndex < port.m_queue_ids.size(); ++queueIndex)
-    {
-        string queueType;
-        uint8_t queueRealIndex = 0;
-        if (getQueueTypeAndIndex(port.m_queue_ids[queueIndex], queueType, queueRealIndex))
-        {
-            if (!queuesState.isQueueCounterEnabled(queueRealIndex))
-            {
-                continue;
-            }
-            // Install a flex counter for this queue to track stats
-            addQueueFlexCountersPerPortPerQueueIndex(port, queueIndex, false);
-        }
-    }
-}
-
-void PortsOrch::addQueueFlexCountersPerPortPerQueueIndex(const Port& port, size_t queueIndex, bool voq)
-{
-    std::unordered_set<string> counter_stats;
-    std::vector<sai_object_id_t> queue_ids;
-
-    for (const auto& it: queue_stat_ids)
-    {
-        counter_stats.emplace(sai_serialize_queue_stat(it));
-    }
-    if (voq)
-    {
-        queue_ids = m_port_voq_ids[port.m_alias];
-    }
-    else
-    {
-        queue_ids = port.m_queue_ids;
-    }
-
-    queue_stat_manager.setCounterIdList(queue_ids[queueIndex], CounterType::QUEUE, counter_stats);
-}
-
-
-void PortsOrch::addQueueWatermarkFlexCounters(map<string, FlexCounterQueueStates> queuesStateVector)
-{
-    if (m_isQueueWatermarkFlexCountersAdded)
-    {
-        return;
-    }
-
-    bool isCreateAllQueues = false;
-
-    if (queuesStateVector.count(createAllAvailableBuffersStr))
-    {
-        isCreateAllQueues = true;
-        queuesStateVector.clear();
-    }
-
-    for (const auto& it: m_portList)
-    {
-        if (it.second.m_type == Port::PHY)
-        {
-            if (!queuesStateVector.count(it.second.m_alias))
-            {
-                auto maxQueueNumber = getNumberOfPortSupportedQueueCounters(it.second.m_alias);
-                FlexCounterQueueStates flexCounterQueueState(maxQueueNumber);
-                if (isCreateAllQueues && maxQueueNumber)
-                {
-                    flexCounterQueueState.enableQueueCounters(0, maxQueueNumber - 1);
-                }
-                queuesStateVector.insert(make_pair(it.second.m_alias, flexCounterQueueState));
-            }
-            addQueueWatermarkFlexCountersPerPort(it.second, queuesStateVector.at(it.second.m_alias));
-        }
-    }
-
-    m_isQueueWatermarkFlexCountersAdded = true;
-}
-
-void PortsOrch::addQueueWatermarkFlexCountersPerPort(const Port& port, FlexCounterQueueStates& queuesState)
-{
-    /* Add stat counters to flex_counter */
-
-    for (size_t queueIndex = 0; queueIndex < port.m_queue_ids.size(); ++queueIndex)
-    {
-        string queueType;
-        uint8_t queueRealIndex = 0;
-        if (getQueueTypeAndIndex(port.m_queue_ids[queueIndex], queueType, queueRealIndex))
-        {
-            if (!queuesState.isQueueCounterEnabled(queueRealIndex))
-            {
-                continue;
-            }
-            addQueueWatermarkFlexCountersPerPortPerQueueIndex(port, queueIndex);
-        }
-    }
-}
-
-void PortsOrch::addQueueWatermarkFlexCountersPerPortPerQueueIndex(const Port& port, size_t queueIndex)
-{
-    const auto id = sai_serialize_object_id(port.m_queue_ids[queueIndex]);
-
-    /* add watermark queue counters */
-    string key = getQueueWatermarkFlexCounterTableKey(id);
-
-    string delimiter("");
-    std::ostringstream counters_stream;
-    for (const auto& it: queueWatermarkStatIds)
-    {
-        counters_stream << delimiter << sai_serialize_queue_stat(it);
-        delimiter = comma;
-    }
-
-    vector<FieldValueTuple> fieldValues;
-    fieldValues.emplace_back(QUEUE_COUNTER_ID_LIST, counters_stream.str());
-
-    m_flexCounterTable->set(key, fieldValues);
-}
-
-void PortsOrch::createPortBufferQueueCounters(const Port &port, string queues)
-{
-    SWSS_LOG_ENTER();
-
-    /* Create the Queue map in the Counter DB */
-    vector<FieldValueTuple> queueVector;
-    vector<FieldValueTuple> queuePortVector;
-    vector<FieldValueTuple> queueIndexVector;
-    vector<FieldValueTuple> queueTypeVector;
-
-    auto toks = tokenize(queues, '-');
-    auto startIndex = to_uint<uint32_t>(toks[0]);
-    auto endIndex = startIndex;
-    if (toks.size() > 1)
-    {
-        endIndex = to_uint<uint32_t>(toks[1]);
-    }
-
-    for (auto queueIndex = startIndex; queueIndex <= endIndex; queueIndex++)
-    {
-        std::ostringstream name;
-        name << port.m_alias << ":" << queueIndex;
-
-        const auto id = sai_serialize_object_id(port.m_queue_ids[queueIndex]);
-
-        string queueType;
-        uint8_t queueRealIndex = 0;
-        if (getQueueTypeAndIndex(port.m_queue_ids[queueIndex], queueType, queueRealIndex))
-        {
-            queueTypeVector.emplace_back(id, queueType);
-            queueIndexVector.emplace_back(id, to_string(queueRealIndex));
-        }
-
-        queueVector.emplace_back(name.str(), id);
-        queuePortVector.emplace_back(id, sai_serialize_object_id(port.m_port_id));
-
-        auto flexCounterOrch = gDirectory.get<FlexCounterOrch*>();
-        if (flexCounterOrch->getQueueCountersState())
-        {
-            // Install a flex counter for this queue to track stats
-            addQueueFlexCountersPerPortPerQueueIndex(port, queueIndex, false);
-        }
-        if (flexCounterOrch->getQueueWatermarkCountersState())
-        {
-            /* add watermark queue counters */
-            addQueueWatermarkFlexCountersPerPortPerQueueIndex(port, queueIndex);
-        }
-    }
-
-    m_queueTable->set("", queueVector);
     m_queuePortTable->set("", queuePortVector);
     m_queueIndexTable->set("", queueIndexVector);
     m_queueTypeTable->set("", queueTypeVector);
@@ -7326,353 +7162,106 @@ void PortsOrch::createPortBufferQueueCounters(const Port &port, string queues)
     CounterCheckOrch::getInstance().addPort(port);
 }
 
-void PortsOrch::removePortBufferQueueCounters(const Port &port, string queues)
-{
-    SWSS_LOG_ENTER();
-
-    /* Remove the Queues maps in the Counter DB */
-    /* Remove stat counters from flex_counter DB */
-    auto toks = tokenize(queues, '-');
-    auto startIndex = to_uint<uint32_t>(toks[0]);
-    auto endIndex = startIndex;
-    if (toks.size() > 1)
-    {
-        endIndex = to_uint<uint32_t>(toks[1]);
-    }
-
-    for (auto queueIndex = startIndex; queueIndex <= endIndex; queueIndex++)
-    {
-        std::ostringstream name;
-        name << port.m_alias << ":" << queueIndex;
-        const auto id = sai_serialize_object_id(port.m_queue_ids[queueIndex]);
-
-        // Remove the queue counter from counters DB maps
-        m_queueTable->hdel("", name.str());
-        m_queuePortTable->hdel("", id);
-
-        string queueType;
-        uint8_t queueRealIndex = 0;
-        if (getQueueTypeAndIndex(port.m_queue_ids[queueIndex], queueType, queueRealIndex))
-        {
-            m_queueTypeTable->hdel("", id);
-            m_queueIndexTable->hdel("", id);
-        }
-
-        auto flexCounterOrch = gDirectory.get<FlexCounterOrch*>();
-        if (flexCounterOrch->getQueueCountersState())
-        {
-            // Remove the flex counter for this queue
-            queue_stat_manager.clearCounterIdList(port.m_queue_ids[queueIndex]);
-        }
-
-        if (flexCounterOrch->getQueueWatermarkCountersState())
-        {
-            // Remove watermark queue counters
-            string key = getQueueWatermarkFlexCounterTableKey(id);
-            m_flexCounterTable->del(key);
-        }
-    }
-
-    CounterCheckOrch::getInstance().removePort(port);
-}
-
-void PortsOrch::generatePriorityGroupMap(map<string, FlexCounterPgStates> pgsStateVector)
+void PortsOrch::generatePriorityGroupMap()
 {
     if (m_isPriorityGroupMapGenerated)
     {
         return;
     }
 
-    bool isCreateAllPgs = false;
-
-    if (pgsStateVector.count(createAllAvailableBuffersStr))
-    {
-        isCreateAllPgs = true;
-        pgsStateVector.clear();
-    }
-
     for (const auto& it: m_portList)
     {
-        if (it.second.m_type == Port::PHY)
+        if (it.second.m_type == Port::PHY && it.second.m_alias.compare(0, strlen(VRRP_PREFIX), VRRP_PREFIX))
         {
-            if (!pgsStateVector.count(it.second.m_alias))
-            {
-                auto maxPgNumber = getNumberOfPortSupportedPgCounters(it.second.m_alias);
-                FlexCounterPgStates flexCounterPgState(maxPgNumber);
-                if (isCreateAllPgs && maxPgNumber)
-                {
-                    flexCounterPgState.enablePgCounters(0, maxPgNumber - 1);
-                }
-                pgsStateVector.insert(make_pair(it.second.m_alias, flexCounterPgState));
-            }
-            generatePriorityGroupMapPerPort(it.second, pgsStateVector.at(it.second.m_alias));
+            generatePriorityGroupMapPerPort(it.second);
         }
     }
 
     m_isPriorityGroupMapGenerated = true;
 }
 
-void PortsOrch::generatePriorityGroupMapPerPort(const Port& port, FlexCounterPgStates& pgsState)
+void PortsOrch::removePriorityGroupMapPerPort(const Port& port)
 {
-    /* Create the PG map in the Counter DB */
-    vector<FieldValueTuple> pgVector;
-    vector<FieldValueTuple> pgPortVector;
-    vector<FieldValueTuple> pgIndexVector;
+    /* Remove the PG map in the Counter DB */
 
     for (size_t pgIndex = 0; pgIndex < port.m_priority_group_ids.size(); ++pgIndex)
-    {
-        if (!pgsState.isPgCounterEnabled(static_cast<uint32_t>(pgIndex)))
-        {
-            continue;
-        }
-        std::ostringstream name;
-        name << port.m_alias << ":" << pgIndex;
-
-        const auto id = sai_serialize_object_id(port.m_priority_group_ids[pgIndex]);
-
-        pgVector.emplace_back(name.str(), id);
-        pgPortVector.emplace_back(id, sai_serialize_object_id(port.m_port_id));
-        pgIndexVector.emplace_back(id, to_string(pgIndex));
-
-    }
-
-    m_pgTable->set("", pgVector);
-    m_pgPortTable->set("", pgPortVector);
-    m_pgIndexTable->set("", pgIndexVector);
-
-    CounterCheckOrch::getInstance().addPort(port);
-}
-
-void PortsOrch::createPortBufferPgCounters(const Port& port, string pgs)
-{
-    SWSS_LOG_ENTER();
-
-    /* Create the PG map in the Counter DB */
-    /* Add stat counters to flex_counter */
-    vector<FieldValueTuple> pgVector;
-    vector<FieldValueTuple> pgPortVector;
-    vector<FieldValueTuple> pgIndexVector;
-
-    auto toks = tokenize(pgs, '-');
-    auto startIndex = to_uint<uint32_t>(toks[0]);
-    auto endIndex = startIndex;
-    if (toks.size() > 1)
-    {
-        endIndex = to_uint<uint32_t>(toks[1]);
-    }
-
-    for (auto pgIndex = startIndex; pgIndex <= endIndex; pgIndex++)
     {
         std::ostringstream name;
         name << port.m_alias << ":" << pgIndex;
 
         const auto id = sai_serialize_object_id(port.m_priority_group_ids[pgIndex]);
+        string key = getPriorityGroupWatermarkFlexCounterTableKey(id);
 
-        pgVector.emplace_back(name.str(), id);
-        pgPortVector.emplace_back(id, sai_serialize_object_id(port.m_port_id));
-        pgIndexVector.emplace_back(id, to_string(pgIndex));
+        m_pgTable->hdel("",name.str());
+        m_pgPortTable->hdel("",id);
+        m_pgIndexTable->hdel("",id);
 
-        auto flexCounterOrch = gDirectory.get<FlexCounterOrch*>();
-        if (flexCounterOrch->getPgCountersState())
-        {
-            /* Add dropped packets counters to flex_counter */
-            addPriorityGroupFlexCountersPerPortPerPgIndex(port, pgIndex);
-        }
-        if (flexCounterOrch->getPgWatermarkCountersState())
-        {
-            /* Add watermark counters to flex_counter */
-            addPriorityGroupWatermarkFlexCountersPerPortPerPgIndex(port, pgIndex);
-        }
-    }
+        m_flexCounterTable->del(key);
 
-    m_pgTable->set("", pgVector);
-    m_pgPortTable->set("", pgPortVector);
-    m_pgIndexTable->set("", pgIndexVector);
-
-    CounterCheckOrch::getInstance().addPort(port);
-}
-
-void PortsOrch::addPriorityGroupFlexCounters(map<string, FlexCounterPgStates> pgsStateVector)
-{
-    if (m_isPriorityGroupFlexCountersAdded)
-    {
-        return;
-    }
-
-    bool isCreateAllPgs = false;
-
-    if (pgsStateVector.count(createAllAvailableBuffersStr))
-    {
-        isCreateAllPgs = true;
-        pgsStateVector.clear();
-    }
-
-    for (const auto& it: m_portList)
-    {
-        if (it.second.m_type == Port::PHY)
-        {
-            if (!pgsStateVector.count(it.second.m_alias))
-            {
-                auto maxPgNumber = getNumberOfPortSupportedPgCounters(it.second.m_alias);
-                FlexCounterPgStates flexCounterPgState(maxPgNumber);
-                if (isCreateAllPgs && maxPgNumber)
-                {
-                    flexCounterPgState.enablePgCounters(0, maxPgNumber - 1);
-                }
-                pgsStateVector.insert(make_pair(it.second.m_alias, flexCounterPgState));
-            }
-            addPriorityGroupFlexCountersPerPort(it.second, pgsStateVector.at(it.second.m_alias));
-        }
-    }
-
-    m_isPriorityGroupFlexCountersAdded = true;
-}
-
-void PortsOrch::addPriorityGroupFlexCountersPerPort(const Port& port, FlexCounterPgStates& pgsState)
-{
-    for (size_t pgIndex = 0; pgIndex < port.m_priority_group_ids.size(); ++pgIndex)
-    {
-        if (!pgsState.isPgCounterEnabled(static_cast<uint32_t>(pgIndex)))
-        {
-            continue;
-        }
-        addPriorityGroupFlexCountersPerPortPerPgIndex(port, pgIndex);
-    }
-}
-
-void PortsOrch::addPriorityGroupFlexCountersPerPortPerPgIndex(const Port& port, size_t pgIndex)
-{
-    const auto id = sai_serialize_object_id(port.m_priority_group_ids[pgIndex]);
-
-    string delimiter = "";
-    std::ostringstream ingress_pg_drop_packets_counters_stream;
-    string key = getPriorityGroupDropPacketsFlexCounterTableKey(id);
-    /* Add dropped packets counters to flex_counter */
-    for (const auto& it: ingressPriorityGroupDropStatIds)
-    {
-        ingress_pg_drop_packets_counters_stream << delimiter << sai_serialize_ingress_priority_group_stat(it);
-        if (delimiter.empty())
-        {
-            delimiter = comma;
-        }
-    }
-    vector<FieldValueTuple> fieldValues;
-    fieldValues.emplace_back(PG_COUNTER_ID_LIST, ingress_pg_drop_packets_counters_stream.str());
-    m_flexCounterTable->set(key, fieldValues);
-}
-
-void PortsOrch::addPriorityGroupWatermarkFlexCounters(map<string, FlexCounterPgStates> pgsStateVector)
-{
-    if (m_isPriorityGroupWatermarkFlexCountersAdded)
-    {
-        return;
-    }
-
-    bool isCreateAllPgs = false;
-
-    if (pgsStateVector.count(createAllAvailableBuffersStr))
-    {
-        isCreateAllPgs = true;
-        pgsStateVector.clear();
-    }
-
-    for (const auto& it: m_portList)
-    {
-        if (it.second.m_type == Port::PHY)
-        {
-            if (!pgsStateVector.count(it.second.m_alias))
-            {
-                auto maxPgNumber = getNumberOfPortSupportedPgCounters(it.second.m_alias);
-                FlexCounterPgStates flexCounterPgState(maxPgNumber);
-                if (isCreateAllPgs && maxPgNumber)
-                {
-                    flexCounterPgState.enablePgCounters(0, maxPgNumber - 1);
-                }
-                pgsStateVector.insert(make_pair(it.second.m_alias, flexCounterPgState));
-            }
-            addPriorityGroupWatermarkFlexCountersPerPort(it.second, pgsStateVector.at(it.second.m_alias));
-        }
-    }
-
-    m_isPriorityGroupWatermarkFlexCountersAdded = true;
-}
-
-void PortsOrch::addPriorityGroupWatermarkFlexCountersPerPort(const Port& port, FlexCounterPgStates& pgsState)
-{
-    /* Add stat counters to flex_counter */
-
-    for (size_t pgIndex = 0; pgIndex < port.m_priority_group_ids.size(); ++pgIndex)
-    {
-        if (!pgsState.isPgCounterEnabled(static_cast<uint32_t>(pgIndex)))
-        {
-            continue;
-        }
-        addPriorityGroupWatermarkFlexCountersPerPortPerPgIndex(port, pgIndex);
-    }
-}
-
-void PortsOrch::addPriorityGroupWatermarkFlexCountersPerPortPerPgIndex(const Port& port, size_t pgIndex)
-{
-    const auto id = sai_serialize_object_id(port.m_priority_group_ids[pgIndex]);
-
-    string key = getPriorityGroupWatermarkFlexCounterTableKey(id);
-
-    std::string delimiter = "";
-    std::ostringstream counters_stream;
-    /* Add watermark counters to flex_counter */
-    for (const auto& it: ingressPriorityGroupWatermarkStatIds)
-    {
-        counters_stream << delimiter << sai_serialize_ingress_priority_group_stat(it);
-        delimiter = comma;
-    }
-
-    vector<FieldValueTuple> fieldValues;
-    fieldValues.emplace_back(PG_COUNTER_ID_LIST, counters_stream.str());
-    m_flexCounterTable->set(key, fieldValues);
-}
-
-void PortsOrch::removePortBufferPgCounters(const Port& port, string pgs)
-{
-    SWSS_LOG_ENTER();
-
-    /* Remove the Pgs maps in the Counter DB */
-    /* Remove stat counters from flex_counter DB */
-    auto toks = tokenize(pgs, '-');
-    auto startIndex = to_uint<uint32_t>(toks[0]);
-    auto endIndex = startIndex;
-    if (toks.size() > 1)
-    {
-        endIndex = to_uint<uint32_t>(toks[1]);
-    }
-
-    for (auto pgIndex = startIndex; pgIndex <= endIndex; pgIndex++)
-    {
-        std::ostringstream name;
-        name << port.m_alias << ":" << pgIndex;
-        const auto id = sai_serialize_object_id(port.m_priority_group_ids[pgIndex]);
-
-        // Remove the pg counter from counters DB maps
-        m_pgTable->hdel("", name.str());
-        m_pgPortTable->hdel("", id);
-        m_pgIndexTable->hdel("", id);
-
-        auto flexCounterOrch = gDirectory.get<FlexCounterOrch*>();
-        if (flexCounterOrch->getPgCountersState())
-        {
-            // Remove dropped packets counters from flex_counter
-            string key = getPriorityGroupDropPacketsFlexCounterTableKey(id);
-            m_flexCounterTable->del(key);
-        }
-
-        if (flexCounterOrch->getPgWatermarkCountersState())
-        {
-            // Remove watermark counters from flex_counter
-            string key = getPriorityGroupWatermarkFlexCounterTableKey(id);
-            m_flexCounterTable->del(key);
-        }
+        key = getPriorityGroupDropPacketsFlexCounterTableKey(id);
+        /* remove dropped packets counters to flex_counter */
+        m_flexCounterTable->del(key);
     }
 
     CounterCheckOrch::getInstance().removePort(port);
+}
+
+void PortsOrch::generatePriorityGroupMapPerPort(const Port& port)
+{
+    /* Create the PG map in the Counter DB */
+    /* Add stat counters to flex_counter */
+    vector<FieldValueTuple> pgVector;
+    vector<FieldValueTuple> pgPortVector;
+    vector<FieldValueTuple> pgIndexVector;
+
+    for (size_t pgIndex = 0; pgIndex < port.m_priority_group_ids.size(); ++pgIndex)
+    {
+        std::ostringstream name;
+        name << port.m_alias << ":" << pgIndex;
+
+        const auto id = sai_serialize_object_id(port.m_priority_group_ids[pgIndex]);
+
+        pgVector.emplace_back(name.str(), id);
+        pgPortVector.emplace_back(id, sai_serialize_object_id(port.m_port_id));
+        pgIndexVector.emplace_back(id, to_string(pgIndex));
+
+        string key = getPriorityGroupWatermarkFlexCounterTableKey(id);
+
+        std::string delimiter = "";
+        std::ostringstream counters_stream;
+        /* Add watermark counters to flex_counter */
+        for (const auto& it: ingressPriorityGroupWatermarkStatIds)
+        {
+            counters_stream << delimiter << sai_serialize_ingress_priority_group_stat(it);
+            delimiter = comma;
+        }
+
+        vector<FieldValueTuple> fieldValues;
+        fieldValues.emplace_back(PG_COUNTER_ID_LIST, counters_stream.str());
+        m_flexCounterTable->set(key, fieldValues);
+
+        delimiter = "";
+        std::ostringstream ingress_pg_drop_packets_counters_stream;
+        key = getPriorityGroupDropPacketsFlexCounterTableKey(id);
+        /* Add dropped packets counters to flex_counter */
+        for (const auto& it: ingressPriorityGroupDropStatIds)
+        {
+            ingress_pg_drop_packets_counters_stream << delimiter << sai_serialize_ingress_priority_group_stat(it);
+            if (delimiter.empty())
+            {
+                delimiter = comma;
+            }
+        }
+        fieldValues.clear();
+        fieldValues.emplace_back(PG_COUNTER_ID_LIST, ingress_pg_drop_packets_counters_stream.str());
+        m_flexCounterTable->set(key, fieldValues);
+    }
+
+    m_pgTable->set("", pgVector);
+    m_pgPortTable->set("", pgPortVector);
+    m_pgIndexTable->set("", pgIndexVector);
+
+    CounterCheckOrch::getInstance().addPort(port);
 }
 
 void PortsOrch::generatePortCounterMap()
@@ -7687,7 +7276,7 @@ void PortsOrch::generatePortCounterMap()
     for (const auto& it: m_portList)
     {
         // Set counter stats only for PHY ports to ensure syncd will not try to query the counter statistics from the HW for non-PHY ports.
-        if (it.second.m_type != Port::Type::PHY)
+        if (it.second.m_type != Port::Type::PHY || !it.second.m_alias.compare(0, strlen(VRRP_PREFIX), VRRP_PREFIX))
         {
             continue;
         }
@@ -7715,7 +7304,7 @@ void PortsOrch::generatePortBufferDropCounterMap()
     for (const auto& it: m_portList)
     {
         // Set counter stats only for PHY ports to ensure syncd will not try to query the counter statistics from the HW for non-PHY ports.
-        if (it.second.m_type != Port::Type::PHY)
+        if (it.second.m_type != Port::Type::PHY || !it.second.m_alias.compare(0, strlen(VRRP_PREFIX), VRRP_PREFIX))
         {
             continue;
         }

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -174,20 +174,8 @@ public:
     bool setPortPfcWatchdogStatus(sai_object_id_t portId, uint8_t pfc_bitmask);
     bool getPortPfcWatchdogStatus(sai_object_id_t portId, uint8_t *pfc_bitmask);
 
-    void generateQueueMap(map<string, FlexCounterQueueStates> queuesStateVector);
-    uint32_t getNumberOfPortSupportedQueueCounters(string port);
-    void createPortBufferQueueCounters(const Port &port, string queues);
-    void removePortBufferQueueCounters(const Port &port, string queues);
-    void addQueueFlexCounters(map<string, FlexCounterQueueStates> queuesStateVector);
-    void addQueueWatermarkFlexCounters(map<string, FlexCounterQueueStates> queuesStateVector);
-
-    void generatePriorityGroupMap(map<string, FlexCounterPgStates> pgsStateVector);
-    uint32_t getNumberOfPortSupportedPgCounters(string port);
-    void createPortBufferPgCounters(const Port &port, string pgs);
-    void removePortBufferPgCounters(const Port& port, string pgs);
-    void addPriorityGroupFlexCounters(map<string, FlexCounterPgStates> pgsStateVector);
-    void addPriorityGroupWatermarkFlexCounters(map<string, FlexCounterPgStates> pgsStateVector);
-
+    void generateQueueMap();
+    void generatePriorityGroupMap();
     void generatePortCounterMap();
     void generatePortBufferDropCounterMap();
 
@@ -424,24 +412,12 @@ private:
     bool getQueueTypeAndIndex(sai_object_id_t queue_id, string &type, uint8_t &index);
 
     bool m_isQueueMapGenerated = false;
-    void generateQueueMapPerPort(const Port& port, FlexCounterQueueStates& queuesState, bool voq);
-    bool m_isQueueFlexCountersAdded = false;
-    void addQueueFlexCountersPerPort(const Port& port, FlexCounterQueueStates& queuesState);
-    void addQueueFlexCountersPerPortPerQueueIndex(const Port& port, size_t queueIndex, bool voq);
-
-    bool m_isQueueWatermarkFlexCountersAdded = false;
-    void addQueueWatermarkFlexCountersPerPort(const Port& port, FlexCounterQueueStates& queuesState);
-    void addQueueWatermarkFlexCountersPerPortPerQueueIndex(const Port& port, size_t queueIndex);
+    void generateQueueMapPerPort(const Port& port, bool voq);
+    void removeQueueMapPerPort(const Port& port);
 
     bool m_isPriorityGroupMapGenerated = false;
-    void generatePriorityGroupMapPerPort(const Port& port, FlexCounterPgStates& pgsState);
-    bool m_isPriorityGroupFlexCountersAdded = false;
-    void addPriorityGroupFlexCountersPerPort(const Port& port, FlexCounterPgStates& pgsState);
-    void addPriorityGroupFlexCountersPerPortPerPgIndex(const Port& port, size_t pgIndex);
-
-    bool m_isPriorityGroupWatermarkFlexCountersAdded = false;
-    void addPriorityGroupWatermarkFlexCountersPerPort(const Port& port, FlexCounterPgStates& pgsState);
-    void addPriorityGroupWatermarkFlexCountersPerPortPerPgIndex(const Port& port, size_t pgIndex);
+    void generatePriorityGroupMapPerPort(const Port& port);
+    void removePriorityGroupMapPerPort(const Port& port);
 
     bool m_isPortCounterMapGenerated = false;
     bool m_isPortBufferDropCounterMapGenerated = false;

--- a/tests/mock_tests/portsorch_ut.cpp
+++ b/tests/mock_tests/portsorch_ut.cpp
@@ -324,14 +324,13 @@ namespace portsorch_test
 
             ASSERT_EQ(gPortsOrch, nullptr);
 
-            gPortsOrch = new PortsOrch(m_app_db.get(), m_state_db.get(), ports_tables, m_chassis_app_db.get());
-
             vector<string> flex_counter_tables = {
                 CFG_FLEX_COUNTER_TABLE_NAME
             };
             auto* flexCounterOrch = new FlexCounterOrch(m_config_db.get(), flex_counter_tables);
             gDirectory.set(flexCounterOrch);
 
+            gPortsOrch = new PortsOrch(m_app_db.get(), m_state_db.get(), ports_tables, m_chassis_app_db.get());
             vector<string> buffer_tables = { APP_BUFFER_POOL_TABLE_NAME,
                                              APP_BUFFER_PROFILE_TABLE_NAME,
                                              APP_BUFFER_QUEUE_TABLE_NAME,

--- a/tests/mock_tests/routeorch_ut.cpp
+++ b/tests/mock_tests/routeorch_ut.cpp
@@ -177,14 +177,14 @@ namespace routeorch_test
                 { APP_NEIGH_SUPPRESS_VLAN_TABLE_NAME, portsorch_base_pri}
             };
 
-            ASSERT_EQ(gPortsOrch, nullptr);
-            gPortsOrch = new PortsOrch(m_app_db.get(), m_state_db.get(), ports_tables, m_chassis_app_db.get());
-
             vector<string> flex_counter_tables = {
                 CFG_FLEX_COUNTER_TABLE_NAME
             };
             auto* flexCounterOrch = new FlexCounterOrch(m_config_db.get(), flex_counter_tables);
             gDirectory.set(flexCounterOrch);
+
+            ASSERT_EQ(gPortsOrch, nullptr);
+            gPortsOrch = new PortsOrch(m_app_db.get(), m_state_db.get(), ports_tables, m_chassis_app_db.get());
 
             static const  vector<string> route_pattern_tables = {
                 CFG_FLOW_COUNTER_ROUTE_PATTERN_TABLE_NAME,

--- a/tests/test_buffer_traditional.py
+++ b/tests/test_buffer_traditional.py
@@ -85,14 +85,12 @@ class TestBuffer(object):
 
     @pytest.fixture
     def setup_teardown_test(self, dvs):
-        self.setup_db(dvs)
-        self.set_port_qos_table(self.INTF, '3,4')
-        self.lossless_pg_combinations = ['3-4']
-        time.sleep(2)
-
-        yield
-
-        self.teardown()
+        try:
+            self.setup_db(dvs)
+            self.set_port_qos_table(self.INTF, '3,4')
+            self.lossless_pg_combinations = ['3-4']
+        finally:
+            self.teardown()
 
     def test_zero_cable_len_profile_update(self, dvs, setup_teardown_test):
         orig_cable_len = None

--- a/tests/test_flex_counters.py
+++ b/tests/test_flex_counters.py
@@ -7,6 +7,8 @@ TUNNEL_TYPE_MAP           = "COUNTERS_TUNNEL_TYPE_MAP"
 ROUTE_TO_PATTERN_MAP      = "COUNTERS_ROUTE_TO_PATTERN_MAP"
 NUMBER_OF_RETRIES         = 10
 CPU_PORT_OID              = "0x0"
+PORT                      = "Ethernet0"
+PORT_MAP                  = "COUNTERS_PORT_NAME_MAP"
 
 counter_group_meta = {
     'port_counter': {
@@ -18,11 +20,6 @@ counter_group_meta = {
     'queue_counter': {
         'key': 'QUEUE',
         'group_name': 'QUEUE_STAT_COUNTER',
-        'name_map': 'COUNTERS_QUEUE_NAME_MAP',
-    },
-    'queue_watermark_counter': {
-        'key': 'QUEUE_WATERMARK',
-        'group_name': 'QUEUE_WATERMARK_STAT_COUNTER',
         'name_map': 'COUNTERS_QUEUE_NAME_MAP',
     },
     'rif_counter': {
@@ -41,11 +38,6 @@ counter_group_meta = {
         'key': 'PORT_BUFFER_DROP',
         'group_name': 'PORT_BUFFER_DROP_STAT',
         'name_map': 'COUNTERS_PORT_NAME_MAP',
-    },
-    'pg_drop_counter': {
-        'key': 'PG_DROP',
-        'group_name': 'PG_DROP_STAT_COUNTER',
-        'name_map': 'COUNTERS_PG_NAME_MAP',
     },
     'pg_watermark_counter': {
         'key': 'PG_WATERMARK',
@@ -81,6 +73,7 @@ counter_group_meta = {
     }
 }
 
+@pytest.mark.usefixtures('dvs_port_manager')
 class TestFlexCounters(object):
 
     def setup_dbs(self, dvs):
@@ -140,18 +133,6 @@ class TestFlexCounters(object):
 
         assert False, "Polling interval is not applied to FLEX_COUNTER_GROUP_TABLE for group {}, expect={}, actual={}".format(group, interval, interval_value)
 
-    def wait_for_buffer_pg_queue_counter(self, map, port, index, isSet):
-        for retry in range(NUMBER_OF_RETRIES):
-            counter_oid = self.counters_db.db_connection.hget(map, port + ':' + index)
-            if (isSet and counter_oid):
-                return counter_oid
-            elif (not isSet and not counter_oid):
-                return None
-            else:
-                time.sleep(1)
-
-        assert False, "Counter not {} for port: {}, type: {}, index: {}".format("created" if isSet else "removed", port, map, index)
-
     def verify_no_flex_counters_tables(self, counter_stat):
         counters_stat_keys = self.flex_db.get_keys("FLEX_COUNTER_TABLE:" + counter_stat)
         assert len(counters_stat_keys) == 0, "FLEX_COUNTER_TABLE:" + str(counter_stat) + " tables exist before enabling the flex counter group"
@@ -199,10 +180,6 @@ class TestFlexCounters(object):
         group_stats_entry = {"POLL_INTERVAL": interval}
         self.config_db.create_entry("FLEX_COUNTER_TABLE", key, group_stats_entry)
         self.wait_for_interval_set(group, interval)
-
-    def set_only_config_db_buffers_field(self, value):
-        fvs = {'create_only_config_db_buffers' : value}
-        self.config_db.update_entry("DEVICE_METADATA", "localhost", fvs)
 
     @pytest.mark.parametrize("counter_type", counter_group_meta.keys())
     def test_flex_counters(self, dvs, counter_type):
@@ -715,131 +692,64 @@ class TestFlexCounters(object):
 
     def set_admin_status(self, interface, status):
         self.config_db.update_entry("PORT", interface, {"admin_status": status})
-
-    @pytest.mark.parametrize('counter_type', [('queue_counter'), ('pg_drop_counter')])
-    def test_create_only_config_db_buffers_false(self, dvs, counter_type):
-        """
-        Test steps:
-            1. By default the configuration knob 'create_only_config_db_value' is missing.
-            2. Get the counter OID for the interface 'Ethernet0:7' from the counters database.
-            3. Perform assertions based on the 'create_only_config_db_value':
-                - If 'create_only_config_db_value' is 'false' or does not exist, assert that the counter OID has a valid OID value.
-
-        Args:
-            dvs (object): virtual switch object
-            counter_type (str): The type of counter being tested
-        """
+            
+    def test_add_remove_ports(self, dvs):
         self.setup_dbs(dvs)
-        meta_data = counter_group_meta[counter_type]
-        self.set_flex_counter_group_status(meta_data['key'], meta_data['name_map'])
-
-        counter_oid = self.counters_db.db_connection.hget(meta_data['name_map'], 'Ethernet0:7')
-        assert counter_oid is not None, "Counter OID should have a valid OID value when create_only_config_db_value is 'false' or does not exist"
-
-    def test_create_remove_buffer_pg_watermark_counter(self, dvs):
-        """
-        Test steps:
-            1. Reset config_db
-            2. Set 'create_only_config_db_buffers' to 'true'
-            3. Enable PG flex counters.
-            4. Configure new buffer prioriy group for a port
-            5. Verify counter is automatically created
-            6. Remove the new buffer prioriy group for the port
-            7. Verify counter is automatically removed
-
-        Args:
-            dvs (object): virtual switch object
-        """
-        dvs.restart()
-        self.setup_dbs(dvs)
-        self.set_only_config_db_buffers_field('true')
-        meta_data = counter_group_meta['pg_watermark_counter']
-
-        self.set_flex_counter_group_status(meta_data['key'], meta_data['name_map'])
-
-        self.config_db.update_entry('BUFFER_PG', 'Ethernet0|1', {'profile': 'ingress_lossy_profile'})
-        counter_oid = self.wait_for_buffer_pg_queue_counter(meta_data['name_map'], 'Ethernet0', '1', True)
-        self.wait_for_id_list(meta_data['group_name'], "Ethernet0", counter_oid)
-
-        self.config_db.delete_entry('BUFFER_PG', 'Ethernet0|1')
-        self.wait_for_buffer_pg_queue_counter(meta_data['name_map'], 'Ethernet0', '1', False)
-        self.wait_for_id_list_remove(meta_data['group_name'], "Ethernet0", counter_oid)
-
-    @pytest.mark.parametrize('counter_type', [('queue_counter'), ('pg_drop_counter')])
-    def test_create_only_config_db_buffers_true(self, dvs, counter_type):
-        """
-        Test steps:
-            1. The 'create_only_config_db_buffers' was set to 'true' by previous test.
-            2. Get the counter OID for the interface 'Ethernet0:7' from the counters database.
-            3. Perform assertions based on the 'create_only_config_db_value':
-                - If 'create_only_config_db_value' is 'true', assert that the counter OID is None.
-
-        Args:
-            dvs (object): virtual switch object
-            counter_type (str): The type of counter being tested
-        """
-        self.setup_dbs(dvs)
-        meta_data = counter_group_meta[counter_type]
-        self.set_flex_counter_group_status(meta_data['key'], meta_data['name_map'])
-
-        counter_oid = self.counters_db.db_connection.hget(meta_data['name_map'], 'Ethernet0:7')
-        assert counter_oid is None, "Counter OID should be None when create_only_config_db_value is 'true'"
-
-    def test_create_remove_buffer_queue_counter(self, dvs):
-        """
-        Test steps:
-            1. Enable Queue flex counters.
-            2. Configure new buffer queue for a port
-            3. Verify counter is automatically created
-            4. Remove the new buffer queue for the port
-            5. Verify counter is automatically removed
-
-        Args:
-            dvs (object): virtual switch object
-        """
-        self.setup_dbs(dvs)
-        meta_data = counter_group_meta['queue_counter']
-
-        self.set_flex_counter_group_status(meta_data['key'], meta_data['name_map'])
-
-        self.config_db.update_entry('BUFFER_QUEUE', 'Ethernet0|7', {'profile': 'egress_lossless_profile'})
-        counter_oid = self.wait_for_buffer_pg_queue_counter(meta_data['name_map'], 'Ethernet0', '7', True)
-        self.wait_for_id_list(meta_data['group_name'], "Ethernet0", counter_oid)
-
-        self.config_db.delete_entry('BUFFER_QUEUE', 'Ethernet0|7')
-        self.wait_for_buffer_pg_queue_counter(meta_data['name_map'], 'Ethernet0', '7', False)
-        self.wait_for_id_list_remove(meta_data['group_name'], "Ethernet0", counter_oid)
-
-    def test_create_remove_buffer_watermark_queue_pg_counter(self, dvs):
-        """
-        Test steps:
-            1. Enable Queue/Watermark/PG-drop flex counters.
-            2. Configure new buffer queue for a port
-            3. Verify counters is automatically created
-            4. Remove the new buffer queue for the port
-            5. Verify counters is automatically removed
-
-        Args:
-            dvs (object): virtual switch object
-        """
-        self.setup_dbs(dvs)
-
+        
         # set flex counter
-        for counterpoll_type, meta_data in counter_group_meta.items():
-            if 'queue' in counterpoll_type or 'pg' in counterpoll_type:
-                self.set_flex_counter_group_status(meta_data['key'], meta_data['name_map'])
+        counter_key = counter_group_meta['queue_counter']['key']
+        counter_stat = counter_group_meta['queue_counter']['group_name']
+        counter_map = counter_group_meta['queue_counter']['name_map']
+        self.set_flex_counter_group_status(counter_key, counter_map)
 
-        self.config_db.update_entry('BUFFER_PG', 'Ethernet0|7', {'profile': 'ingress_lossy_profile'})
-        self.config_db.update_entry('BUFFER_QUEUE', 'Ethernet0|7', {'profile': 'egress_lossless_profile'})
+        # receive port info
+        fvs = self.config_db.get_entry("PORT", PORT)
+        assert len(fvs) > 0
+        
+        # save all the oids of the pg drop counters            
+        oid_list = []
+        counters_queue_map = self.counters_db.get_entry("COUNTERS_QUEUE_NAME_MAP", "")
+        for key, oid in counters_queue_map.items():
+            if PORT in key:
+                oid_list.append(oid)
+                fields = self.flex_db.get_entry("FLEX_COUNTER_TABLE", counter_stat + ":%s" % oid)
+                assert len(fields) == 1
+        oid_list_len = len(oid_list)
 
-        for counterpoll_type, meta_data in counter_group_meta.items():
-            if 'queue' in counterpoll_type or 'pg' in counterpoll_type:
-                counter_oid = self.wait_for_buffer_pg_queue_counter(meta_data['name_map'], 'Ethernet0', '7', True)
-                self.wait_for_id_list(meta_data['group_name'], "Ethernet0", counter_oid)
+        # get port oid
+        port_oid = self.counters_db.get_entry(PORT_MAP, "")[PORT]
 
-        self.config_db.delete_entry('BUFFER_QUEUE', 'Ethernet0|7')
-        self.config_db.delete_entry('BUFFER_PG', 'Ethernet0|7')
-        for counterpoll_type, meta_data in counter_group_meta.items():
-            if 'queue' in counterpoll_type or 'pg' in counterpoll_type:
-                self.wait_for_buffer_pg_queue_counter(meta_data['name_map'], 'Ethernet0', '7', False)
-                self.wait_for_id_list_remove(meta_data['group_name'], "Ethernet0", counter_oid)
+        # remove port and verify that it was removed properly
+        self.dvs_port.remove_port(PORT)
+        dvs.get_asic_db().wait_for_deleted_entry("ASIC_STATE:SAI_OBJECT_TYPE_PORT", port_oid)
+        
+        # verify counters were removed from flex counter table
+        for oid in oid_list:
+            fields = self.flex_db.get_entry("FLEX_COUNTER_TABLE", counter_stat + ":%s" % oid)
+            assert len(fields) == 0
+        
+        # verify that port counter maps were removed from counters db
+        counters_queue_map = self.counters_db.get_entry("COUNTERS_QUEUE_NAME_MAP", "")
+        for key in counters_queue_map.keys():
+            if PORT in key:
+                assert False
+        
+        # add port and wait until the port is added on asic db
+        num_of_keys_without_port = len(dvs.get_asic_db().get_keys("ASIC_STATE:SAI_OBJECT_TYPE_PORT"))
+        
+        self.config_db.create_entry("PORT", PORT, fvs)
+        
+        dvs.get_asic_db().wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_PORT", num_of_keys_without_port + 1)
+        dvs.get_counters_db().wait_for_fields("COUNTERS_QUEUE_NAME_MAP", "", ["%s:0"%(PORT)])
+        
+        # verify queue counters were added
+        oid_list = []
+        counters_queue_map = self.counters_db.get_entry("COUNTERS_QUEUE_NAME_MAP", "")
+
+        for key, oid in counters_queue_map.items():
+            if PORT in key:
+                oid_list.append(oid)
+                fields = self.flex_db.get_entry("FLEX_COUNTER_TABLE", counter_stat + ":%s" % oid)
+                assert len(fields) == 1
+        # the number of the oids needs to be the same as the original number of oids (before removing a port and adding)
+        assert oid_list_len == len(oid_list)

--- a/tests/test_pg_drop_counter.py
+++ b/tests/test_pg_drop_counter.py
@@ -2,12 +2,16 @@ import os
 import re
 import time
 import json
+import pytest
 import redis
 
 from swsscommon import swsscommon
 
 pg_drop_attr = "SAI_INGRESS_PRIORITY_GROUP_STAT_DROPPED_PACKETS"
 
+PORT = "Ethernet0"
+
+@pytest.mark.usefixtures('dvs_port_manager')
 class TestPGDropCounter(object):
     DEFAULT_POLL_INTERVAL = 10
     pgs = {}
@@ -57,11 +61,14 @@ class TestPGDropCounter(object):
             assert found, "entry name %s not found" % (entry_name)
 
     def set_up_flex_counter(self):
+        pg_stats_entry = {"PG_COUNTER_ID_LIST": "{}".format(pg_drop_attr)}
+        for pg in self.pgs:
+            self.flex_db.create_entry("FLEX_COUNTER_TABLE", "PG_DROP_STAT_COUNTER:{}".format(pg), pg_stats_entry)
+
         fc_status_enable = {"FLEX_COUNTER_STATUS": "enable"}
+
         self.config_db.create_entry("FLEX_COUNTER_TABLE", "PG_DROP", fc_status_enable)
         self.config_db.create_entry("FLEX_COUNTER_TABLE", "PG_WATERMARK", fc_status_enable)
-        # Wait for DB's to populate by orchagent
-        time.sleep(2)
 
     def clear_flex_counter(self):
         for pg in self.pgs:
@@ -72,12 +79,10 @@ class TestPGDropCounter(object):
         
     def test_pg_drop_counters(self, dvs):
         self.setup_dbs(dvs)
-        self.set_up_flex_counter()
-        # Get all configured counters OID's
-        self.pgs = self.counters_db.db_connection.hgetall("COUNTERS_PG_NAME_MAP").values()
-        assert self.pgs is not None and len(self.pgs) > 0
-
+        self.pgs = self.asic_db.get_keys("ASIC_STATE:SAI_OBJECT_TYPE_INGRESS_PRIORITY_GROUP")
         try:
+            self.set_up_flex_counter()
+
             self.populate_asic(dvs, "0")
             time.sleep(self.DEFAULT_POLL_INTERVAL)
             self.verify_value(dvs, self.pgs, pg_drop_attr, "0")
@@ -92,3 +97,48 @@ class TestPGDropCounter(object):
         finally:
             self.clear_flex_counter()
 
+    def test_pg_drop_counter_port_add_remove(self, dvs):
+        self.setup_dbs(dvs)
+
+        try:
+            # configure pg drop flex counter
+            self.set_up_flex_counter()
+
+            # receive port info
+            fvs = self.config_db.get_entry("PORT", PORT)
+            assert len(fvs) > 0
+        
+            # save all the oids of the pg drop counters            
+            oid_list = []
+            for priority in range(0,7):
+                oid_list.append(dvs.get_counters_db().get_entry("COUNTERS_PG_NAME_MAP", "")["%s:%d"%(PORT, priority)])
+                # verify that counters exists on flex counter
+                fields = self.flex_db.get_entry("FLEX_COUNTER_TABLE", "PG_WATERMARK_STAT_COUNTER:%s"%oid_list[-1])
+                assert len(fields) == 1
+
+            # remove port
+            port_oid = self.counters_db.get_entry("COUNTERS_PORT_NAME_MAP", "")[PORT]
+            self.dvs_port.remove_port(PORT)
+            dvs.get_asic_db().wait_for_deleted_entry("ASIC_STATE:SAI_OBJECT_TYPE_PORT", port_oid)
+        
+            # verify counters were removed from flex counter table
+            for oid in oid_list:
+                fields = self.flex_db.get_entry("FLEX_COUNTER_TABLE", "PG_WATERMARK_STAT_COUNTER:%s"%oid)
+                assert len(fields) == 0
+              
+            # add port and wait until the port is added on asic db
+            num_of_keys_without_port = len(dvs.get_asic_db().get_keys("ASIC_STATE:SAI_OBJECT_TYPE_PORT"))
+            self.config_db.create_entry("PORT", PORT, fvs)
+            dvs.get_asic_db().wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_PORT", num_of_keys_without_port + 1)
+            dvs.get_counters_db().wait_for_fields("COUNTERS_PG_NAME_MAP", "", ["%s:0"%(PORT)])
+            
+            # verify counter was added
+            for priority in range(0,7):
+                oid = dvs.get_counters_db().get_entry("COUNTERS_PG_NAME_MAP", "")["%s:%d"%(PORT, priority)]
+      
+                # verify that counters exists on flex counter
+                fields = self.flex_db.get_entry("FLEX_COUNTER_TABLE", "PG_WATERMARK_STAT_COUNTER:%s"%oid)
+                assert len(fields) == 1
+            
+        finally:
+            self.clear_flex_counter()

--- a/tests/test_virtual_chassis.py
+++ b/tests/test_virtual_chassis.py
@@ -909,33 +909,6 @@ class TestVirtualChassis(object):
                 assert logSeen.strip() == "1"
 
             buffer_model.disable_dynamic_buffer(dvs.get_config_db(), dvs.runcmd)
-
-    def test_voq_egress_queue_counter(self, vct):
-        if vct is None:
-            return
-        dvss = vct.dvss
-        dvs = None
-        for name in dvss.keys():
-            if "supervisor" in name:
-                continue
-            dvs = dvss[name]
-            break
-        assert dvs
-        _, _ = dvs.runcmd("counterpoll queue enable")
-
-        num_voqs_per_port = 8
-        # vs-switch creates 20 queues per port.
-        num_queues_per_local_port = 20
-        num_ports_per_linecard = 32
-        num_local_ports = 32
-        num_linecards = 3
-        num_sysports =  num_ports_per_linecard * num_linecards
-        num_egress_queues = num_local_ports * num_queues_per_local_port
-        num_voqs = ( num_ports_per_linecard * num_voqs_per_port * num_linecards )
-        num_queues_to_be_polled = num_voqs + num_egress_queues
-
-        flex_db = dvs.get_flex_db()
-        flex_db.wait_for_n_keys("FLEX_COUNTER_TABLE:QUEUE_STAT_COUNTER", num_queues_to_be_polled)
  
     def test_chassis_wred_profile_on_system_ports(self, vct):
         """Test whether wred profile is applied on system ports in VoQ chassis.


### PR DESCRIPTION
**What I did**
Revert "[202311][DPB] Show PG/queue counters would fail after port breakout".
Revert "[FlexCounters] Fixed orchagent crash issue#2395 (#2936)".
Revert "[buffers] Add handler for the 'create_only_config_db_buffers' configuration knob (#2883)".
Revert "Fix egress queue counters in voq systems. (#2706)".
Revert "swss: Fix Invalid port oid messages generated because of voq counters. (#2653)".
Revert "sonic-swss: Fix orchagent crash in generateQueueMapPerPort. (#2552)".
Revert "Align watermark flow with port configuration (#2525)".
Revert "[counters] Improve performance by polling only configured ports buffer queue/pg counters (#2473)"

**Why I did it**
"[counters] Improve performance by polling only configured ports buffer queue/pg counters" commit and related commit cause the queue counter and watermark to only display the buffer configuration bindings, so when you run the "config qos clear" command, the queue counter and watermark are removed.

**How I verified it**
Verify that the queue counter are still present when the qos clear command is performed.
