### PR TITLE
[VRF] Remove the restriction to check route nexthop and router interface whether belong to the same VRF

### DIFF
--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -1787,27 +1787,11 @@ bool RouteOrch::addRoute(RouteBulkContext& ctx, const NextHopGroupKey &nextHops)
                 return true;
             }
 
-            Port port;
-            /* Cannot locate interface */
-            if (!gPortsOrch->getPort(nexthop.alias, port))
-            {
-                SWSS_LOG_INFO("Failed to get interface %s",
-                        nexthop.alias.c_str());
-                return false;
-            }
-
             next_hop_id = m_intfsOrch->getRouterIntfsId(nexthop.alias);
             /* rif is not created yet */
             if (next_hop_id == SAI_NULL_OBJECT_ID)
             {
                 SWSS_LOG_INFO("Failed to get next hop %s for %s",
-                        nextHops.to_string().c_str(), ipPrefix.to_string().c_str());
-                return false;
-            }
-
-            if (vrf_id != port.m_vr_id)
-            {
-                SWSS_LOG_INFO("Interface in Next hop %s for %s belongs to different vrf",
                         nextHops.to_string().c_str(), ipPrefix.to_string().c_str());
                 return false;
             }


### PR DESCRIPTION
**What I did**
remove the restriction to check route nexthop and router interface whether belong to the same VRF in order to add connected route through route leaking successfully.

**Why I did it**
When using FRR to configure static route leaking between different VRFs(default and Vrf1), the route will not be write into ASIC

**How I verified it**
Setting up cross-VRF routes

**Before**
![58f56e8f-ffc0-4beb-a971-8861deb41c11](https://github.com/user-attachments/assets/98526c93-17b1-457a-9d6c-951b51ffc475)
![e89cae33-f968-4624-9e35-e7ff11517c51](https://github.com/user-attachments/assets/fdfb2c59-ec35-4d57-b8ee-f79a0b26031b)

**Affter:**
![042046aa-ad94-49a6-8aea-83b8072a0ff8](https://github.com/user-attachments/assets/7f47635f-b028-4260-9b3b-c3755c29d5c8)
![86f57af4-c96a-4528-b614-eff2fb35522c](https://github.com/user-attachments/assets/e9960ced-3819-4126-92cd-8f64a091d564)

