### PR TITLE
[routeorch] The connected route need to retry if router interface is removing

### DIFF
--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -113,6 +113,14 @@ IntfsOrch::IntfsOrch(DBConnector *db, DBConnector *stateDb, vector<table_name_wi
 
 }
 
+bool IntfsOrch::isRouterIntfRemoving(const string &alias)
+{
+    if (m_syncdIntfses.find(alias) == m_syncdIntfses.end() || !m_syncdIntfses[alias].remove_intf_hw_pending)
+        return false;
+
+    return true;
+}
+
 sai_object_id_t IntfsOrch::getRouterIntfsId(const string &alias)
 {
     Port port;

--- a/orchagent/intfsorch.h
+++ b/orchagent/intfsorch.h
@@ -76,6 +76,8 @@ public:
     bool isRemoteSystemPortIntf(string alias);
     bool isLocalSystemPortIntf(string alias);
 
+    bool isRouterIntfRemoving(const string &alias);
+
 private:
 
     SelectableTimer* m_updateMapsTimer = nullptr;

--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -1798,7 +1798,7 @@ bool RouteOrch::addRoute(RouteBulkContext& ctx, const NextHopGroupKey &nextHops)
 
             next_hop_id = m_intfsOrch->getRouterIntfsId(nexthop.alias);
             /* rif is not created yet */
-            if (next_hop_id == SAI_NULL_OBJECT_ID)
+            if (next_hop_id == SAI_NULL_OBJECT_ID || m_intfsOrch->isRouterIntfRemoving(nexthop.alias))
             {
                 SWSS_LOG_INFO("Failed to get next hop %s for %s",
                         nextHops.to_string().c_str(), ipPrefix.to_string().c_str());
@@ -2097,7 +2097,7 @@ bool RouteOrch::addRoutePost(const RouteBulkContext& ctx, const NextHopGroupKey 
         {
             auto next_hop_id = m_intfsOrch->getRouterIntfsId(nexthop.alias);
             /* rif is not created yet */
-            if (next_hop_id == SAI_NULL_OBJECT_ID)
+            if (next_hop_id == SAI_NULL_OBJECT_ID || m_intfsOrch->isRouterIntfRemoving(nexthop.alias))
             {
                 SWSS_LOG_INFO("Failed to get next hop %s for %s",
                         nextHops.to_string().c_str(), ipPrefix.to_string().c_str());


### PR DESCRIPTION
What I did
The connected route need to retry if router interface is removing.

Why I did it
To prevent the sai to add route leaking for the general connected route.

How I verified it
1. Setting up cross-VRF routes
2. shutdown and startup the interface

Before:
```
root@as9736-64d-4:/home/admin# bcmcmd "l3 host show"
l3 host show
         VRF Net Addr            INTF UL_INTF S-HIT D-HIT
-------------------------------------------------------------
1       1    10.0.0.57           100023 0    n    n            <---------------
2       1    60.60.60.61         100002 0    n    n
3       0    10.1.0.32           100002 0    n    n
4       0    10.0.0.56           100002 0    n    n
5       0    10.0.0.57           100031 0    n    n            <---------------
```
After:
```
root@as9736-64d-4:/home/admin# bcmcmd "l3 host show"
l3 host show
         VRF Net Addr            INTF UL_INTF S-HIT D-HIT
-------------------------------------------------------------
1       1    10.0.0.57           100023 0    n    n            <---------------
2       1    60.60.60.61         100002 0    n    n
3       0    10.1.0.32           100002 0    n    n
4       0    10.0.0.56           100002 0    n    n
5       0    10.0.0.57           100023 0    n    n            <---------------
```