### PR TITLE
Revert "[MCLAG][Workaround] Only support configuring isolation peer-link and members through the APP isolation group"

### DIFF
--- a/mclagsyncd/mclaglink.cpp
+++ b/mclagsyncd/mclaglink.cpp
@@ -195,8 +195,8 @@ void MclagLink::setPortIsolate(char *msg)
         CTC_PLATFORM_SUBSTRING
     };
 
-//    const char *platform = getenv("platform");
-//    if (platform != nullptr && supported.find(string(platform)) != supported.end())
+    const char *platform = getenv("platform");
+    if (platform != nullptr && supported.find(string(platform)) != supported.end())
     {
         mclag_sub_option_hdr_t *op_hdr = NULL;
         string isolate_src_port;
@@ -277,7 +277,6 @@ void MclagLink::setPortIsolate(char *msg)
                     isolate_dst_port.c_str());
         }
     }
-#if 0 /* Not suuport acl mclag rule */
     else
     {
         mclag_sub_option_hdr_t *op_hdr = NULL;
@@ -371,7 +370,7 @@ void MclagLink::setPortIsolate(char *msg)
         p_acl_rule_tbl->set(acl_rule_name, acl_rule_attrs);
         /*End create ACL rule table*/
     }
-#endif
+
     return;
 }
 


### PR DESCRIPTION
Revert "[MCLAG][Workaround] Only support configuring isolation peer-link and members through the APP isolation group"

This reverts commit 0acb880abb63102c83cb7cb35b01584cb824b626.