### PR TITLE
[ACL] Reverted previously removed code to fix ACL table creation failure.

### DIFF
--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -4640,6 +4640,8 @@ void AclOrch::doAclTableTask(Consumer &consumer)
             }
 
             newTable.validateAddType(*tableType);
+            // Add mandatory ACL action if not present
+            newTable.addMandatoryActions();
 
             newTable.addStageMandatoryMatchFields();
 


### PR DESCRIPTION
**What I did**
Reverted the previously removed code.

**Why I did it**
 On 202311.X with Broadcom SAI, creating an ACL table failed because required code had been removed. As a result, the ACL table could not be created, and the following error messages appeared in the syslog:

  ``` 
May  7 14:35:27.541019 as9736-64d-3 ERR swss#orchagent: :- validate: Action list for table TEST_ACL is mandatory 
May  7 14:35:27.541209 as9736-64d-3 INFO caclmgrd[16261]: ACL change detected for namespace '' 
May  7 14:35:27.541321 as9736-64d-3 ERR swss#orchagent: :- doAclTableTask: Failed to create ACL table TEST_ACL, invalid configuration 
```

**How I verified it**
Tested ACL table creation on 202311.X with both Broadcom SAI and ecSAI; verified that the table could be created successfully without errors.