### PR TITLE
[switch capabilities] Avoid logging ERR for known-unsupported attributes

### DIFF
--- a/orchagent/switch/switch_capabilities.cpp
+++ b/orchagent/switch/switch_capabilities.cpp
@@ -340,6 +340,16 @@ void SwitchCapabilities::queryHashNativeHashFieldListEnumCapabilities()
     auto status = queryEnumCapabilitiesSai(
         hfList, SAI_OBJECT_TYPE_HASH, SAI_HASH_ATTR_NATIVE_HASH_FIELD_LIST
     );
+
+    if (status == SAI_STATUS_NOT_SUPPORTED)
+    {
+        SWSS_LOG_WARN(
+            "Attribute(%s) enum capability query is not supported",
+            toStr(SAI_OBJECT_TYPE_HASH, SAI_HASH_ATTR_NATIVE_HASH_FIELD_LIST).c_str()
+        );
+        return;
+    }
+
     if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR(
@@ -364,9 +374,25 @@ void SwitchCapabilities::queryHashNativeHashFieldListAttrCapabilities()
 
     sai_attr_capability_t attrCap;
 
+    const sai_attr_metadata_t *meta = sai_metadata_get_attr_metadata(SAI_OBJECT_TYPE_HASH, SAI_HASH_ATTR_NATIVE_HASH_FIELD_LIST);
+    if (meta && !meta->capability) {
+        SWSS_LOG_WARN("Skipping capability query for unimplemented attribute: %s", meta->attridname);
+        return;
+    }
+
     auto status = queryAttrCapabilitiesSai(
         attrCap, SAI_OBJECT_TYPE_HASH, SAI_HASH_ATTR_NATIVE_HASH_FIELD_LIST
     );
+
+    if (status == SAI_STATUS_NOT_SUPPORTED)
+    {
+        SWSS_LOG_WARN(
+            "Attribute(%s) capability query is not supported",
+            toStr(SAI_OBJECT_TYPE_HASH, SAI_HASH_ATTR_NATIVE_HASH_FIELD_LIST).c_str()
+        );
+        return;
+    }
+
     if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR(
@@ -462,6 +488,16 @@ void SwitchCapabilities::querySwitchEcmpHashAlgorithmEnumCapabilities()
     auto status = queryEnumCapabilitiesSai(
         haList, SAI_OBJECT_TYPE_SWITCH, SAI_SWITCH_ATTR_ECMP_DEFAULT_HASH_ALGORITHM
     );
+
+    if (status == SAI_STATUS_NOT_SUPPORTED)
+    {
+        SWSS_LOG_WARN(
+            "Attribute(%s) enum capability query is not supported",
+            toStr(SAI_OBJECT_TYPE_SWITCH, SAI_SWITCH_ATTR_ECMP_DEFAULT_HASH_ALGORITHM).c_str()
+        );
+        return;
+    }
+
     if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR(
@@ -518,6 +554,16 @@ void SwitchCapabilities::querySwitchLagHashAlgorithmEnumCapabilities()
     auto status = queryEnumCapabilitiesSai(
         haList, SAI_OBJECT_TYPE_SWITCH, SAI_SWITCH_ATTR_LAG_DEFAULT_HASH_ALGORITHM
     );
+
+    if (status == SAI_STATUS_NOT_SUPPORTED)
+    {
+        SWSS_LOG_WARN(
+            "Attribute(%s) enum capability query is not supported",
+            toStr(SAI_OBJECT_TYPE_SWITCH, SAI_SWITCH_ATTR_LAG_DEFAULT_HASH_ALGORITHM).c_str()
+        );
+        return;
+    }
+
     if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR(


### PR DESCRIPTION
- Why I did it

Fix the following syslog which may cause sonic-mgmt log analyzer failure:

May 12 01:55:57.707028 as9736-64d-5 ERR swss#orchagent: :- queryHashNativeHashFieldListEnumCapabilities: Failed to get attribute(SAI_HASH_ATTR_NATIVE_HASH_FIELD_LIST) enum value capabilities

May 12 01:55:57.707711 as9736-64d-5 ERR swss#orchagent: :- queryHashNativeHashFieldListAttrCapabilities: Failed to get attribute(SAI_HASH_ATTR_NATIVE_HASH_FIELD_LIST) capabilities

May 12 01:55:57.709714 as9736-64d-5 ERR swss#orchagent: :- querySwitchEcmpHashAlgorithmEnumCapabilities: Failed to get attribute(SAI_SWITCH_ATTR_ECMP_DEFAULT_HASH_ALGORITHM) enum value capabilities

May 12 01:55:57.711142 as9736-64d-5 ERR swss#orchagent: :- querySwitchLagHashAlgorithmEnumCapabilities: Failed to get attribute(SAI_SWITCH_ATTR_LAG_DEFAULT_HASH_ALGORITHM) enum value capabilities

- How I did it
1. Skip querying unsupported SAI attributes by checking sai_metadata capabilities
2. Check SAI_STATUS_NOT_SUPPORTED

- How I verified it
Check syslog
