### PR TITLE
Retry FDB Entry Addition on Table Full Error

### DIFF
--- a/orchagent/saihelper.cpp
+++ b/orchagent/saihelper.cpp
@@ -511,6 +511,8 @@ task_process_status handleSaiCreateStatus(sai_api_t api, sai_status_t status, vo
                      *  and orchagent should ignore the error and treat it as entry was explicitly created.
                      */
                     return task_success;
+                case SAI_STATUS_TABLE_FULL:
+                    return task_need_retry;
                 default:
                     SWSS_LOG_ERROR("Encountered failure in create operation, exiting orchagent, SAI API: %s, status: %s",
                                 sai_serialize_api(api).c_str(), sai_serialize_status(status).c_str());


### PR DESCRIPTION
**What I did**
Implemented retry logic when adding FDB entries fails due to table full error.

**Why I did it**
Previously, orchagent would crash when attempting to add an FDB entry after the table had reached its capacity. 
This change prevents such crashes by retrying the operation with proper handling.

**How I verified it**
Ran a test case that attempts to insert more FDB entries than the hardware supports. Verified that the system no longer crashes and handles the error gracefully.