### PR TITLE
Handle Table Full Error Without Retry on FDB Entry Addition

### DIFF
--- a/orchagent/fdborch.cpp
+++ b/orchagent/fdborch.cpp
@@ -1735,7 +1735,14 @@ bool FdbOrch::addFdbEntry(const FdbEntry& entry, const string& port_name,
         SWSS_LOG_INFO("MAC-Create %s FDB %s in %s on %s", fdbData.type.c_str(), entry.mac.to_string().c_str(), vlan.m_alias.c_str(), port_name.c_str());
 
         status = sai_fdb_api->create_fdb_entry(&fdb_entry, (uint32_t)attrs.size(), attrs.data());
-        if (status != SAI_STATUS_SUCCESS)
+        if (status == SAI_STATUS_TABLE_FULL || status == SAI_STATUS_INSUFFICIENT_RESOURCES)
+        {
+            SWSS_LOG_WARN("Failed to create %s FDB %s in %s on %s, rv:%d",
+                    fdbData.type.c_str(), entry.mac.to_string().c_str(),
+                    vlan.m_alias.c_str(), port_name.c_str(), status);
+            return true; // No need to retry when FDB table is full
+        }
+        else if (status != SAI_STATUS_SUCCESS)
         {
             SWSS_LOG_ERROR("Failed to create %s FDB %s in %s on %s, rv:%d",
                     fdbData.type.c_str(), entry.mac.to_string().c_str(),


### PR DESCRIPTION
**What I did**
Added logic to handle SAI "table full" or "insufficient resources" error on FDB Entry Addition

**Why I did it**
The Table Full Error is not handled on FDB Entry Addition. Retrying FDB entry addition after receiving a table full error is ineffective and unnecessary. The retry will continue to fail unless an entry with the same hash key is removed or aged out.

**How I verified it**
Tested the behavior by filling the FDB table to its capacity and attempting to add new entries. Confirmed that the system logs the table full condition once without retrying, and continues processing other entries normally.
