### PR TITLE
Add Xsight patch for X2

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -4683,23 +4683,22 @@ void PortsOrch::doVlanMemberTask(Consumer &consumer)
         {
             if (getPort(vlan_alias, vlan) && vlan.m_members.find(port_alias) != vlan.m_members.end())
             {
-                if (!removeVlanMember(vlan, port))
+                if (removeVlanMember(vlan, port))
+                {
+                    if (m_portVlanMember[port.m_alias].empty())
+                    {
+                        removeBridgePort(port);
+                    }
+                    it = consumer.m_toSync.erase(it);
+                }
+                else
                 {
                     it++;
-                    continue;
                 }
             }
-
-            if (m_portVlanMember[port.m_alias].empty())
-            {
-                if (!removeBridgePort(port))
-                {
-                    it++;
-                    continue;
-                }
-            }
-
-            it = consumer.m_toSync.erase(it);
+            else
+                /* Cannot locate the VLAN */
+                it = consumer.m_toSync.erase(it);
         }
         else
         {
@@ -5920,13 +5919,6 @@ bool PortsOrch::removeBridgePort(Port &port)
     //Flush the FDB entires corresponding to the port
     gFdbOrch->flushFDBEntries(port.m_bridge_port_id, SAI_NULL_OBJECT_ID);
     SWSS_LOG_INFO("Flush FDB entries for port %s", port.m_alias.c_str());
-
-    if (port.m_fdb_count != 0)
-    {
-        // SWSS_LOG_NOTICE("Still has %d FDB entries, couldn't remove bridge port %s",
-        //         port.m_fdb_count, port.m_alias.c_str());
-        return false;
-    }
 
     /* Remove bridge port */
     PortUpdate update = { port, false };


### PR DESCRIPTION
- Updated VLAN member task to improve logic for removing VLAN members and handling bridge ports.

- Ensured proper handling of FDB entries during bridge port removal.

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

- Add Xsight patch for X2 testing

**Why I did it**

- Add Xsight patch for X2 testing

**How I verified it**

**Details if related**
