### PR TITLE
Get the maximum port number from the PORT_TABLE in APPDB instead of calculating it from netdevs.

### DIFF
--- a/cfgmgr/stpmgr.cpp
+++ b/cfgmgr/stpmgr.cpp
@@ -17,6 +17,8 @@
 using namespace std;
 using namespace swss;
 
+#define ETHERNET_PREFIX "Ethernet"
+
 StpMgr::StpMgr(DBConnector *confDb, DBConnector *applDb, DBConnector *statDb,
         const vector<TableConnector> &tables) :
     Orch(tables),
@@ -30,8 +32,8 @@ StpMgr::StpMgr(DBConnector *confDb, DBConnector *applDb, DBConnector *statDb,
     m_stateLagTable(statDb, STATE_LAG_TABLE_NAME),
     m_stateStpTable(statDb, STATE_STP_TABLE_NAME),
     m_stateVlanMemberTable(statDb, STATE_VLAN_MEMBER_TABLE_NAME),
-    m_appCoppTableProducer(applDb, APP_COPP_TABLE_NAME)
-
+    m_appCoppTableProducer(applDb, APP_COPP_TABLE_NAME),
+    m_appPortTable(applDb, APP_PORT_TABLE_NAME)
 {
     SWSS_LOG_ENTER();
     l2ProtoEnabled = L2_NONE;
@@ -1111,6 +1113,32 @@ uint16_t StpMgr::getStpMaxInstances(void)
     }
 
     return max_stp_instances;
+}
+
+uint16_t StpMgr::getMaxPortNumber(void)
+{
+    uint16_t maxPortNumber = 0;
+    string etherPrefix = ETHERNET_PREFIX;
+
+    vector<string> portTableKeys;
+    m_appPortTable.getKeys(portTableKeys);
+
+    for (auto key : portTableKeys)
+    {
+        size_t pos = key.find(etherPrefix);
+        if (pos == string::npos)
+            continue;
+
+        string portNumberStr = key.substr(pos + etherPrefix.length());
+        uint16_t portNumber = static_cast<uint16_t>(stoi(portNumberStr.c_str()));
+
+        if (maxPortNumber < portNumber)
+        {
+            maxPortNumber = portNumber;
+        }
+    }
+
+    return maxPortNumber;
 }
 
 void StpMgr::enableCoppRule(void)

--- a/cfgmgr/stpmgr.h
+++ b/cfgmgr/stpmgr.h
@@ -97,6 +97,7 @@ typedef struct STP_IPC_MSG {
 typedef struct STP_INIT_READY_MSG {
     uint8_t  opcode; // enable/disable
     uint16_t max_stp_instances;
+    uint16_t max_port_number;
     // Example: potential extra padding if alignment warnings arise
     // uint8_t  padding[1];
 } ALIGNED(4) STP_INIT_READY_MSG;
@@ -195,6 +196,7 @@ public:
     MacAddress macAddress;
     bool isPortInitDone(DBConnector *app_db);
     uint16_t getStpMaxInstances(void);
+    uint16_t getMaxPortNumber(void);
 
 private:
     Table m_cfgStpGlobalTable;
@@ -207,6 +209,7 @@ private:
     Table m_stateVlanMemberTable;
     Table m_stateLagTable;
     Table m_stateStpTable;
+    Table m_appPortTable;
     ProducerStateTable m_appCoppTableProducer;
 
     std::bitset<L2_INSTANCE_MAX> l2InstPool;

--- a/cfgmgr/stpmgrd.cpp
+++ b/cfgmgr/stpmgrd.cpp
@@ -69,6 +69,7 @@ int main(int argc, char **argv)
         STP_INIT_READY_MSG msg;
         memset(&msg, 0, sizeof(STP_INIT_READY_MSG));
         msg.max_stp_instances = stpmgr.getStpMaxInstances();
+        msg.max_port_number = stpmgr.getMaxPortNumber();
         stpmgr.sendMsgStpd(STP_INIT_READY, sizeof(msg), (void *)&msg);
 
         // Get Base MAC


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Get the maximum port number from the PORT_TABLE in APPDB instead of calculating it from netdevs.

**Why I did it**
During a fast reboot: when stpmgrd informs stpd that ports are ready, some network devices (netdevs) may not be fully created yet. As a result, stpd calculates a lower-than-actual maximum port number, leading to insufficient memory allocation.

**How I verified it**
Execute 'fast-reboot' to make sure the maximum port number is correct.

**Details if related**
```
Aug 15 13:42:35.421788 as9736-64d-4 INFO stp#stp#stpd: stp_intf_event_mgr_init:619:intf db done. max port 1032
Aug 15 06:12:08.821033 as9736-64d-4 INFO stp#stp#stpd: stp_intf_event_mgr_init:613:intf db done. max port 1032
Aug 15 06:23:44.033068 as9736-64d-4 INFO stp#stp#stpd: stp_intf_event_mgr_init:619:intf db done. max port 1032
Aug 15 06:26:57.789474 as9736-64d-4 INFO stp#stp#stpd: stp_intf_event_mgr_init:619:intf db done. max port 1032
Aug 15 06:31:11.628875 as9736-64d-4 INFO stp#stp#stpd: stp_intf_event_mgr_init:619:intf db done. max port 1032
Aug 15 06:37:44.771785 as9736-64d-4 INFO stp#stp#stpd: stp_intf_event_mgr_init:619:intf db done. max port 1032
```

**Notes**
Related to https://github.com/edge-core/sonic-stp/pull/6.