### PR TITLE
[intfsorch] Check invalid neighbor to apply after adding IP on router interface

### DIFF
--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -1131,6 +1131,29 @@ void IntfsOrch::doTask(Consumer &consumer)
                 setIntfProxyArp(alias, proxy_arp);
             }
 
+            if (ip_prefix_in_key)
+            {
+                TableDump invalid_nhes;
+                gNeighOrch->getInvalidNeighborEntry(invalid_nhes);
+
+                for (const auto &inhe: invalid_nhes)
+                {
+                    size_t found = inhe.first.find('|');
+                    string alias = inhe.first.substr(0, found);
+                    IpAddress ip_address(inhe.first.substr(found+1));
+                    TableMap attr = inhe.second;
+                    string vrf_name = attr["vrf_name"];
+                    string mac_address = attr["neigh"];
+                    string reason = attr["reason"];
+
+                    if (isIpInIntfSubnet(ip_address, alias, vrf_name) && reason == "invalid_subnet")
+                    {
+                        NeighborEntry neighbor_entry = { ip_address, alias };
+                        gNeighOrch->applyInvalidNeighborEntry(neighbor_entry, mac_address, inhe.first);
+                    }
+                }
+            }
+
             it = consumer.m_toSync.erase(it);
         }
         else if (op == DEL_COMMAND)

--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -762,6 +762,33 @@ bool NeighOrch::getNeighborEntry(const IpAddress &ipAddress, NeighborEntry &neig
     return getNeighborEntry(nexthop, neighborEntry, macAddress);
 }
 
+void NeighOrch::getInvalidNeighborEntry(TableDump& invalid_nhe)
+{
+    vector<string> keys;
+    m_stateNeighInvalidTable->getKeys(keys);
+
+    for (const auto &key: keys)
+    {
+        vector<FieldValueTuple> values;
+        TableMap map;
+
+        m_stateNeighInvalidTable->get(key, values);
+
+        for (const auto &value: values)
+            map[value.first] = value.second;
+
+        invalid_nhe[key] = map;
+    }
+}
+
+void NeighOrch::applyInvalidNeighborEntry(const NeighborEntry &neighbor_entry, const MacAddress &mac_address, const string state_key)
+{
+    if (addNeighbor(neighbor_entry, mac_address))
+    {
+        m_stateNeighInvalidTable->del(state_key);
+    }
+}
+
 void NeighOrch::doTask(Consumer &consumer)
 {
     SWSS_LOG_ENTER();
@@ -866,6 +893,23 @@ void NeighOrch::doTask(Consumer &consumer)
                  && gIntfsOrch->isIpInIntfSubnet(ip_address, alias, vrf_name)== false)
             {
                 SWSS_LOG_WARN("IP %s not in alias %s subnet", ip_address.to_string().c_str(), alias.c_str());
+
+                string state_key = alias + state_db_key_delimiter + ip_address.to_string();
+                vector<FieldValueTuple> fvVector;
+                FieldValueTuple mac("neigh", mac_address.to_string());
+                fvVector.push_back(mac);
+
+                FieldValueTuple family("family", ip_address.isV4() ? "IPv4" : "IPv6");
+                fvVector.push_back(family);
+
+                FieldValueTuple vrf("vrf_name", vrf_name);
+                fvVector.push_back(vrf);
+
+                FieldValueTuple reason("reason", "invalid_subnet");
+                fvVector.push_back(reason);
+
+                m_stateNeighInvalidTable->set(state_key, fvVector);
+
                 it = consumer.m_toSync.erase(it);
                 continue;
             }

--- a/orchagent/neighorch.h
+++ b/orchagent/neighorch.h
@@ -82,6 +82,8 @@ public:
     void resolveNeighbor(const NeighborEntry &);
     void updateSrv6Nexthop(const NextHopKey &, const sai_object_id_t &);
 
+    void getInvalidNeighborEntry(TableDump& invalid_nhe);
+    void applyInvalidNeighborEntry(const NeighborEntry &neighbor_entry, const MacAddress &mac_address, const string state_key);
 private:
     PortsOrch *m_portsOrch;
     IntfsOrch *m_intfsOrch;


### PR DESCRIPTION
**What I did**
Updated intfsorch to check m_stateNeighInvalidTable when a new IP is added on a router interface.
Ensured neighbors belonging to the same subnet are properly re-applied after the IP address is configured.

**Why I did it**
Without this check, some neighbors in the same subnet may remain unhandled after assigning an IP on the router interface.
This could cause missing neighbor entries and traffic disruption.

**How I verified it**
Added IP addresses to router interfaces in a testbed with existing neighbors in the same subnet.
Observed that previously invalid neighbors were re-applied successfully.