### PR TITLE
Retry RIF and VRF Addition on Table Full

### DIFF
--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -1496,9 +1496,10 @@ bool IntfsOrch::addRouterIntfs(sai_object_id_t vrf_id, Port &port, string loopba
     {
         SWSS_LOG_ERROR("Failed to create router interface %s, rv:%d",
                 port.m_alias.c_str(), status);
-        if (handleSaiCreateStatus(SAI_API_ROUTER_INTERFACE, status) != task_success)
+        task_process_status handle_status = handleSaiCreateStatus(SAI_API_ROUTER_INTERFACE, status);
+        if (handle_status != task_success)
         {
-            throw runtime_error("Failed to create router interface.");
+            return parseHandleSaiStatusFailure(handle_status);
         }
     }
 

--- a/orchagent/saihelper.cpp
+++ b/orchagent/saihelper.cpp
@@ -629,6 +629,22 @@ task_process_status handleSaiCreateStatus(sai_api_t api, sai_status_t status, vo
                     break;
             }
             break;
+        case SAI_API_ROUTER_INTERFACE:
+        case SAI_API_VIRTUAL_ROUTER:
+            switch (status)
+            {
+                case SAI_STATUS_SUCCESS:
+                    return task_success;
+                case SAI_STATUS_INSUFFICIENT_RESOURCES:
+                case SAI_STATUS_TABLE_FULL:
+                    return task_need_retry;
+                default:
+                    SWSS_LOG_ERROR("Encountered failure in create operation, exiting orchagent, SAI API: %s, status: %s",
+                                sai_serialize_api(api).c_str(), sai_serialize_status(status).c_str());
+                    handleSaiFailure(true);
+                    break;
+            }
+            break;
         default:
             switch (status)
             {


### PR DESCRIPTION
**What I did**
Modified the logic to retry adding Router Interface (RIF) and VRF entries when SAI returns INSUFFICIENT_RESOURCES or TABLE_FULL.

**Why I did it**
Previously, Orchagent crash if the RIF or VRF addition failed due to table full. 
Retrying allows the operation to succeed once resources are available, improving system stability.

**How I verified it**
Simulated resource constraints and table-full conditions on target devices. 
Verified that Orchagent no longer crashes and retries successfully until the entries are added.