### PR TITLE
Revert "Updated VLAN member task to improve logic for removing VLAN m…

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -4683,22 +4683,23 @@ void PortsOrch::doVlanMemberTask(Consumer &consumer)
         {
             if (getPort(vlan_alias, vlan) && vlan.m_members.find(port_alias) != vlan.m_members.end())
             {
-                if (removeVlanMember(vlan, port))
-                {
-                    if (m_portVlanMember[port.m_alias].empty())
-                    {
-                        removeBridgePort(port);
-                    }
-                    it = consumer.m_toSync.erase(it);
-                }
-                else
+                if (!removeVlanMember(vlan, port))
                 {
                     it++;
+                    continue;
                 }
             }
-            else
-                /* Cannot locate the VLAN */
-                it = consumer.m_toSync.erase(it);
+
+            if (m_portVlanMember[port.m_alias].empty())
+            {
+                if (!removeBridgePort(port))
+                {
+                    it++;
+                    continue;
+                }
+            }
+
+            it = consumer.m_toSync.erase(it);
         }
         else
         {
@@ -5919,6 +5920,13 @@ bool PortsOrch::removeBridgePort(Port &port)
     //Flush the FDB entires corresponding to the port
     gFdbOrch->flushFDBEntries(port.m_bridge_port_id, SAI_NULL_OBJECT_ID);
     SWSS_LOG_INFO("Flush FDB entries for port %s", port.m_alias.c_str());
+
+    if (port.m_fdb_count != 0)
+    {
+        // SWSS_LOG_NOTICE("Still has %d FDB entries, couldn't remove bridge port %s",
+        //         port.m_fdb_count, port.m_alias.c_str());
+        return false;
+    }
 
     /* Remove bridge port */
     PortUpdate update = { port, false };


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Reverted commit with FDB changes which were done as workaround for Xsight SAI

**Why I did it**

XSAI since version 1.13.3-3 supports FDB Flush notifications so workaround in orchagent is not needed any more

**How I verified it**

Built SONiC image and ran sonic-mgmt and manual tests

**Details if related**
