### PR TITLE
[mock_tests] Fix Orch object file descriptor leak in test TearDown

### DIFF
--- a/tests/mock_tests/bufferorch_ut.cpp
+++ b/tests/mock_tests/bufferorch_ut.cpp
@@ -379,6 +379,7 @@ namespace bufferorch_test
                 i.second->clear();
             }
 
+            delete gDirectory.get<FlexCounterOrch*>();
             gDirectory.m_values.clear();
 
             delete gCrmOrch;

--- a/tests/mock_tests/fdborch/flush_syncd_notif_ut.cpp
+++ b/tests/mock_tests/fdborch/flush_syncd_notif_ut.cpp
@@ -144,6 +144,7 @@ namespace fdb_syncd_flush_test
             delete gNeighOrch;
             gNeighOrch = nullptr;
 
+            delete gDirectory.get<VxlanTunnelOrch*>();
             gDirectory.m_values.clear();
             ut_helper::uninitSaiApi();
         }

--- a/tests/mock_tests/flowcounterrouteorch_ut.cpp
+++ b/tests/mock_tests/flowcounterrouteorch_ut.cpp
@@ -42,6 +42,8 @@ namespace flowcounterrouteorch_test
 
     struct FlowcounterRouteOrchTest : public ::testing::Test
     {
+        TunnelDecapOrch *m_tunnel_decap_orch = nullptr;
+
         FlowcounterRouteOrchTest()
         {
             return;
@@ -181,6 +183,7 @@ namespace flowcounterrouteorch_test
             gNeighOrch = new NeighOrch(m_app_db.get(), APP_NEIGH_TABLE_NAME, gIntfsOrch, gFdbOrch, gPortsOrch, gVrfOrch, m_chassis_app_db.get());
 
             auto* tunnel_decap_orch = new TunnelDecapOrch(m_app_db.get(), APP_TUNNEL_DECAP_TABLE_NAME);
+            m_tunnel_decap_orch = tunnel_decap_orch;
             vector<string> mux_tables = {
                 CFG_MUX_CABLE_TABLE_NAME,
                 CFG_PEER_SWITCH_TABLE_NAME
@@ -293,6 +296,14 @@ namespace flowcounterrouteorch_test
 
         void TearDown() override
         {
+            auto* mux_orch = gDirectory.get<MuxOrch*>();
+            delete mux_orch;
+            delete m_tunnel_decap_orch;
+            m_tunnel_decap_orch = nullptr;
+            delete gDirectory.get<FlexCounterOrch*>();
+            delete gDirectory.get<VNetOrch*>();
+            delete gDirectory.get<VNetCfgRouteOrch*>();
+            delete gDirectory.get<VNetRouteOrch*>();
             gDirectory.m_values.clear();
 
             delete gCrmOrch;

--- a/tests/mock_tests/intfsorch_ut.cpp
+++ b/tests/mock_tests/intfsorch_ut.cpp
@@ -38,6 +38,7 @@ namespace intfsorch_test
 
     struct IntfsOrchTest : public ::testing::Test
     {
+        TunnelDecapOrch *m_tunnel_decap_orch = nullptr;
         shared_ptr<swss::DBConnector> m_app_db;
         shared_ptr<swss::DBConnector> m_config_db;
         shared_ptr<swss::DBConnector> m_state_db;
@@ -174,6 +175,7 @@ namespace intfsorch_test
             gNeighOrch = new NeighOrch(m_app_db.get(), APP_NEIGH_TABLE_NAME, gIntfsOrch, gFdbOrch, gPortsOrch, gVrfOrch, m_chassis_app_db.get());
 
             auto* tunnel_decap_orch = new TunnelDecapOrch(m_app_db.get(), APP_TUNNEL_DECAP_TABLE_NAME);
+            m_tunnel_decap_orch = tunnel_decap_orch;
             vector<string> mux_tables = {
                 CFG_MUX_CABLE_TABLE_NAME,
                 CFG_PEER_SWITCH_TABLE_NAME
@@ -244,6 +246,14 @@ namespace intfsorch_test
 
         void TearDown() override
         {
+            auto* mux_orch = gDirectory.get<MuxOrch*>();
+            delete mux_orch;
+            delete m_tunnel_decap_orch;
+            m_tunnel_decap_orch = nullptr;
+            delete gDirectory.get<FlexCounterOrch*>();
+            delete gDirectory.get<VNetOrch*>();
+            delete gDirectory.get<VNetCfgRouteOrch*>();
+            delete gDirectory.get<VNetRouteOrch*>();
             gDirectory.m_values.clear();
 
             delete gCrmOrch;

--- a/tests/mock_tests/mux_rollback_ut.cpp
+++ b/tests/mock_tests/mux_rollback_ut.cpp
@@ -283,6 +283,7 @@ namespace mux_rollback_test
                 APP_BUFFER_PORT_EGRESS_PROFILE_LIST_NAME
             };
             gBufferOrch = new BufferOrch(m_app_db.get(), m_config_db.get(), m_state_db.get(), buffer_tables);
+            ut_orch_list.push_back((Orch **)&gBufferOrch);
 
             TableConnector stateDbSwitchTable(m_state_db.get(), STATE_SWITCH_CAPABILITY_TABLE_NAME);
             TableConnector app_switch_table(m_app_db.get(), APP_SWITCH_TABLE_NAME);

--- a/tests/mock_tests/portsorch_ut.cpp
+++ b/tests/mock_tests/portsorch_ut.cpp
@@ -450,6 +450,7 @@ namespace portsorch_test
             gSwitchOrch = nullptr;
 
             // clear orchs saved in directory
+            delete gDirectory.get<FlexCounterOrch*>();
             gDirectory.m_values.clear();
         }
 

--- a/tests/mock_tests/qosorch_ut.cpp
+++ b/tests/mock_tests/qosorch_ut.cpp
@@ -585,6 +585,7 @@ namespace qosorch_test
                 i.second->clear();
             }
 
+            delete gDirectory.get<FlexCounterOrch*>();
             gDirectory.m_values.clear();
 
             delete gCrmOrch;

--- a/tests/mock_tests/routeorch_ut.cpp
+++ b/tests/mock_tests/routeorch_ut.cpp
@@ -91,6 +91,8 @@ namespace routeorch_test
 
     struct RouteOrchTest : public ::testing::Test
     {
+        TunnelDecapOrch *m_tunnel_decap_orch = nullptr;
+
         RouteOrchTest()
         {
         }
@@ -220,6 +222,7 @@ namespace routeorch_test
             gNeighOrch = new NeighOrch(m_app_db.get(), APP_NEIGH_TABLE_NAME, gIntfsOrch, gFdbOrch, gPortsOrch, gVrfOrch, m_chassis_app_db.get());
 
             TunnelDecapOrch *tunnel_decap_orch = new TunnelDecapOrch(m_app_db.get(), APP_TUNNEL_DECAP_TABLE_NAME);
+            m_tunnel_decap_orch = tunnel_decap_orch;
             vector<string> mux_tables = {
                 CFG_MUX_CABLE_TABLE_NAME,
                 CFG_PEER_SWITCH_TABLE_NAME
@@ -313,6 +316,12 @@ namespace routeorch_test
 
         void TearDown() override
         {
+            auto* mux_orch = gDirectory.get<MuxOrch*>();
+            delete mux_orch;
+            delete m_tunnel_decap_orch;
+            m_tunnel_decap_orch = nullptr;
+            delete gDirectory.get<FlexCounterOrch*>();
+            delete gDirectory.get<FlowCounterRouteOrch*>();
             gDirectory.m_values.clear();
 
             delete gCrmOrch;


### PR DESCRIPTION
## [mock_tests] Fix Orch object file descriptor leak in test TearDown

### Description

Fix file descriptor leaks in mock test fixtures that cause `"Too many open files"` errors when running the full test suite sequentially.

### Root Cause

Each mock test `SetUp()` creates multiple Orch objects via `new` and stores them in `gDirectory` using `gDirectory.set()`. However, in `TearDown()`:

```cpp
gDirectory.m_values.clear();  // Only clears map entries, does NOT delete objects
```

`Directory::m_values` is `std::unordered_map<std::string, Orch*>`. Calling `clear()` removes map entries but **never invokes destructors** on the pointed-to objects.

Since `mock_dbconnector.cpp` creates **real OS sockets** (`socket(AF_UNIX, SOCK_DGRAM, 0)`) for each `DBConnector`, and each Orch object internally holds multiple `DBConnector`/`RedisPipeline`/`Table` instances, the leaked sockets accumulate across test runs until the process hits the `ulimit -n` limit.

### Fix

Before `gDirectory.m_values.clear()`, retrieve and `delete` all Orch objects stored in gDirectory that are not otherwise cleaned up via global pointer deletion:

```cpp
// Example from routeorch_ut.cpp
void TearDown() override
{
    auto* mux_orch = gDirectory.get<MuxOrch*>();
    delete mux_orch;
    delete m_tunnel_decap_orch;
    m_tunnel_decap_orch = nullptr;
    delete gDirectory.get<FlexCounterOrch*>();
    delete gDirectory.get<FlowCounterRouteOrch*>();
    gDirectory.m_values.clear();
    // ... existing global pointer deletes ...
}
```

For `TunnelDecapOrch` (not stored in gDirectory, passed as local variable to `MuxOrch` constructor), promote to a class member (`m_tunnel_decap_orch`) to enable proper cleanup.

For `mux_rollback_ut.cpp` (uses `ut_orch_list` for reverse-order deletion), add the missing `gBufferOrch` to `ut_orch_list`.

### Changed Files (8 files, all under `tests/mock_tests/`)

| File | Leaked Objects Fixed |
|------|---------------------|
| `portsorch_ut.cpp` | `FlexCounterOrch` |
| `routeorch_ut.cpp` | `MuxOrch`, `TunnelDecapOrch` (member), `FlexCounterOrch`, `FlowCounterRouteOrch` |
| `qosorch_ut.cpp` | `FlexCounterOrch` |
| `bufferorch_ut.cpp` | `FlexCounterOrch` |
| `fdborch/flush_syncd_notif_ut.cpp` | `VxlanTunnelOrch` |
| `intfsorch_ut.cpp` | `MuxOrch`, `TunnelDecapOrch` (member), `FlexCounterOrch`, `VNetOrch`, `VNetCfgRouteOrch`, `VNetRouteOrch` |
| `flowcounterrouteorch_ut.cpp` | `MuxOrch`, `TunnelDecapOrch` (member), `FlexCounterOrch`, `VNetOrch`, `VNetCfgRouteOrch`, `VNetRouteOrch` |
| `mux_rollback_ut.cpp` | `BufferOrch` (added to `ut_orch_list`) |

### Test Results

- **Build**: Successful, zero compile errors
- **Mock tests**: **119/119 PASSED**, 0 FAILED
- **Test suites**: 23 test suites, all green

### Risk Assessment

- **Risk Level**: Low
- **Scope**: Test code only (`tests/mock_tests/`), no production code changes
- **Backwards Compatibility**: No impact on production behavior
