### PR TITLE
orchagent/stporch: Add platform check for virtual switch in StpOrch constructor

### DIFF
--- a/orchagent/stporch.cpp
+++ b/orchagent/stporch.cpp
@@ -1,4 +1,5 @@
 #include <tuple>
+#include <string>
 #include "portsorch.h"
 #include "logger.h"
 #include "fdborch.h"
@@ -17,6 +18,16 @@ StpOrch::StpOrch(DBConnector * db, DBConnector * stateDb, vector<string> &tableN
     Orch(db, tableNames)
 {
     SWSS_LOG_ENTER();
+
+    // Check if platform is "vs" (virtual switch)
+    const char *platform = getenv("platform");
+    if (platform && string(platform) == "vs")
+    {
+        SWSS_LOG_WARN("vs platform is not supported, SAI STP not initialized");
+        m_defaultStpId = SAI_NULL_OBJECT_ID;
+        m_stpTable = unique_ptr<Table>(new Table(stateDb, STATE_STP_TABLE_NAME));
+        return;
+    }
 
     sai_attribute_t attr;
     sai_status_t status;

--- a/orchagent/vrforch.cpp
+++ b/orchagent/vrforch.cpp
@@ -27,7 +27,6 @@ extern PortsOrch*            gPortsOrch;
 extern MclagAaOrch*     gMclagAaOrch;
 extern FlowCounterRouteOrch* gFlowCounterRouteOrch;
 extern RouteOrch*            gRouteOrch;
-
 bool VRFOrch::addOperation(const Request& request)
 {
     SWSS_LOG_ENTER();

--- a/tests/mock_tests/stporch_ut.cpp
+++ b/tests/mock_tests/stporch_ut.cpp
@@ -243,4 +243,38 @@ namespace stporch_test
         _unhook_sai_vlan_api();
         _unhook_sai_fdb_api();
     }
+
+    TEST_F(StpOrchTest, TestVsPlatformCheck) {
+        // Test that when platform is "vs", the constructor returns early without initialization
+        const char* old_platform = getenv("platform");
+        
+        // Set platform to "vs"
+        setenv("platform", "vs", 1);
+        
+        // Create a new StpOrch instance
+        // This should detect vs platform and skip initialization
+        vector<string> tableNames = {
+            "STP_TABLE",
+            "STP_VLAN_INSTANCE_TABLE",
+            "STP_PORT_STATE_TABLE",
+            "STP_FASTAGEING_FLUSH_TABLE"
+        };
+        
+        // The constructor should log a warning and return early
+        StpOrch* stp_vs = new StpOrch(m_app_db.get(), m_state_db.get(), tableNames);
+        ASSERT_NE(stp_vs, nullptr);
+        
+        // Verify that m_defaultStpId is not set (should be SAI_NULL_OBJECT_ID)
+        // This indicates the initialization was skipped
+        ASSERT_EQ(stp_vs->m_defaultStpId, SAI_NULL_OBJECT_ID);
+        
+        delete stp_vs;
+        
+        // Restore original platform environment
+        if (old_platform) {
+            setenv("platform", old_platform, 1);
+        } else {
+            unsetenv("platform");
+        }
+    }
 }


### PR DESCRIPTION
# Title:
orchagent/stporch: Add platform check for virtual switch in StpOrch constructor

# Description:

**What I did**
Added platform detection in StpOrch constructor to skip SAI STP initialization on virtual switch (vs) platform.
When platform is detected as "vs", the constructor logs a WARN message and returns early instead of attempting to query SAI switch attributes.

**Why I did it**
StpOrch initialization fails on virtual switch platform with SAI_STATUS_NOT_IMPLEMENTED for SAI_SWITCH_ATTR_MAX_STP_INSTANCE attribute because the vssai library (sonic-sairedis/vslib) does not implement this attribute.

This causes orchagent to crash with:
- Error: `StpOrch initialization failure`
- Impact: SWSS service fails to start on virtual switch platforms

**How I verified it**
- Verified platform detection logic correctly identifies "vs" platform
- Verified early return prevents SAI API calls on vs platform
- Verified non-vs platforms proceed with normal initialization
- Added unit test coverage for TestVsPlatformCheck in mock_tests/stporch_ut.cpp

**Details if related**
Related Issue: orchagent crash on vs (virtual switch) platform
- sairedis.rec shows: SAI_STATUS_NOT_IMPLEMENTED for get_switch_attribute
- Root cause: vssai does not implement SAI_SWITCH_ATTR_MAX_STP_INSTANCE

Modified files:
- orchagent/stporch.cpp: Added platform check at constructor start
- tests/mock_tests/stporch_ut.cpp: Added unit test coverage