### PR TITLE
[SONiC build issue] [mock_tests] Fix Orch object fd leak in test TearDown

### DIFF
--- a/tests/mock_tests/bufferorch_ut.cpp
+++ b/tests/mock_tests/bufferorch_ut.cpp
@@ -379,6 +379,7 @@ namespace bufferorch_test
                 i.second->clear();
             }
 
+            delete gDirectory.get<FlexCounterOrch*>();
             gDirectory.m_values.clear();
 
             delete gCrmOrch;

--- a/tests/mock_tests/fdborch/flush_syncd_notif_ut.cpp
+++ b/tests/mock_tests/fdborch/flush_syncd_notif_ut.cpp
@@ -144,6 +144,7 @@ namespace fdb_syncd_flush_test
             delete gNeighOrch;
             gNeighOrch = nullptr;
 
+            delete gDirectory.get<VxlanTunnelOrch*>();
             gDirectory.m_values.clear();
             ut_helper::uninitSaiApi();
         }

--- a/tests/mock_tests/flowcounterrouteorch_ut.cpp
+++ b/tests/mock_tests/flowcounterrouteorch_ut.cpp
@@ -42,6 +42,8 @@ namespace flowcounterrouteorch_test
 
     struct FlowcounterRouteOrchTest : public ::testing::Test
     {
+        TunnelDecapOrch *m_tunnel_decap_orch = nullptr;
+
         FlowcounterRouteOrchTest()
         {
             return;
@@ -181,6 +183,7 @@ namespace flowcounterrouteorch_test
             gNeighOrch = new NeighOrch(m_app_db.get(), APP_NEIGH_TABLE_NAME, gIntfsOrch, gFdbOrch, gPortsOrch, gVrfOrch, m_chassis_app_db.get());
 
             auto* tunnel_decap_orch = new TunnelDecapOrch(m_app_db.get(), APP_TUNNEL_DECAP_TABLE_NAME);
+            m_tunnel_decap_orch = tunnel_decap_orch;
             vector<string> mux_tables = {
                 CFG_MUX_CABLE_TABLE_NAME,
                 CFG_PEER_SWITCH_TABLE_NAME
@@ -293,6 +296,14 @@ namespace flowcounterrouteorch_test
 
         void TearDown() override
         {
+            auto* mux_orch = gDirectory.get<MuxOrch*>();
+            delete mux_orch;
+            delete m_tunnel_decap_orch;
+            m_tunnel_decap_orch = nullptr;
+            delete gDirectory.get<FlexCounterOrch*>();
+            delete gDirectory.get<VNetOrch*>();
+            delete gDirectory.get<VNetCfgRouteOrch*>();
+            delete gDirectory.get<VNetRouteOrch*>();
             gDirectory.m_values.clear();
 
             delete gCrmOrch;

--- a/tests/mock_tests/intfsorch_ut.cpp
+++ b/tests/mock_tests/intfsorch_ut.cpp
@@ -38,6 +38,7 @@ namespace intfsorch_test
 
     struct IntfsOrchTest : public ::testing::Test
     {
+        TunnelDecapOrch *m_tunnel_decap_orch = nullptr;
         shared_ptr<swss::DBConnector> m_app_db;
         shared_ptr<swss::DBConnector> m_config_db;
         shared_ptr<swss::DBConnector> m_state_db;
@@ -174,6 +175,7 @@ namespace intfsorch_test
             gNeighOrch = new NeighOrch(m_app_db.get(), APP_NEIGH_TABLE_NAME, gIntfsOrch, gFdbOrch, gPortsOrch, gVrfOrch, m_chassis_app_db.get());
 
             auto* tunnel_decap_orch = new TunnelDecapOrch(m_app_db.get(), APP_TUNNEL_DECAP_TABLE_NAME);
+            m_tunnel_decap_orch = tunnel_decap_orch;
             vector<string> mux_tables = {
                 CFG_MUX_CABLE_TABLE_NAME,
                 CFG_PEER_SWITCH_TABLE_NAME
@@ -244,6 +246,14 @@ namespace intfsorch_test
 
         void TearDown() override
         {
+            auto* mux_orch = gDirectory.get<MuxOrch*>();
+            delete mux_orch;
+            delete m_tunnel_decap_orch;
+            m_tunnel_decap_orch = nullptr;
+            delete gDirectory.get<FlexCounterOrch*>();
+            delete gDirectory.get<VNetOrch*>();
+            delete gDirectory.get<VNetCfgRouteOrch*>();
+            delete gDirectory.get<VNetRouteOrch*>();
             gDirectory.m_values.clear();
 
             delete gCrmOrch;

--- a/tests/mock_tests/mux_rollback_ut.cpp
+++ b/tests/mock_tests/mux_rollback_ut.cpp
@@ -283,6 +283,7 @@ namespace mux_rollback_test
                 APP_BUFFER_PORT_EGRESS_PROFILE_LIST_NAME
             };
             gBufferOrch = new BufferOrch(m_app_db.get(), m_config_db.get(), m_state_db.get(), buffer_tables);
+            ut_orch_list.push_back((Orch **)&gBufferOrch);
 
             TableConnector stateDbSwitchTable(m_state_db.get(), STATE_SWITCH_CAPABILITY_TABLE_NAME);
             TableConnector app_switch_table(m_app_db.get(), APP_SWITCH_TABLE_NAME);

--- a/tests/mock_tests/portsorch_ut.cpp
+++ b/tests/mock_tests/portsorch_ut.cpp
@@ -450,6 +450,7 @@ namespace portsorch_test
             gSwitchOrch = nullptr;
 
             // clear orchs saved in directory
+            delete gDirectory.get<FlexCounterOrch*>();
             gDirectory.m_values.clear();
         }
 

--- a/tests/mock_tests/qosorch_ut.cpp
+++ b/tests/mock_tests/qosorch_ut.cpp
@@ -585,6 +585,7 @@ namespace qosorch_test
                 i.second->clear();
             }
 
+            delete gDirectory.get<FlexCounterOrch*>();
             gDirectory.m_values.clear();
 
             delete gCrmOrch;

--- a/tests/mock_tests/routeorch_ut.cpp
+++ b/tests/mock_tests/routeorch_ut.cpp
@@ -91,6 +91,8 @@ namespace routeorch_test
 
     struct RouteOrchTest : public ::testing::Test
     {
+        TunnelDecapOrch *m_tunnel_decap_orch = nullptr;
+
         RouteOrchTest()
         {
         }
@@ -220,6 +222,7 @@ namespace routeorch_test
             gNeighOrch = new NeighOrch(m_app_db.get(), APP_NEIGH_TABLE_NAME, gIntfsOrch, gFdbOrch, gPortsOrch, gVrfOrch, m_chassis_app_db.get());
 
             TunnelDecapOrch *tunnel_decap_orch = new TunnelDecapOrch(m_app_db.get(), APP_TUNNEL_DECAP_TABLE_NAME);
+            m_tunnel_decap_orch = tunnel_decap_orch;
             vector<string> mux_tables = {
                 CFG_MUX_CABLE_TABLE_NAME,
                 CFG_PEER_SWITCH_TABLE_NAME
@@ -313,6 +316,12 @@ namespace routeorch_test
 
         void TearDown() override
         {
+            auto* mux_orch = gDirectory.get<MuxOrch*>();
+            delete mux_orch;
+            delete m_tunnel_decap_orch;
+            m_tunnel_decap_orch = nullptr;
+            delete gDirectory.get<FlexCounterOrch*>();
+            delete gDirectory.get<FlowCounterRouteOrch*>();
             gDirectory.m_values.clear();
 
             delete gCrmOrch;


### PR DESCRIPTION
Fix file descriptor leak in mock test fixtures caused by gDirectory.m_values.clear() not deleting the pointed Orch objects.

Each Orch object holds real OS sockets created by mock DBConnector (socket(AF_UNIX, SOCK_DGRAM, 0)). When TearDown only clears the gDirectory map without deleting the objects, these sockets accumulate across test runs, eventually causing "Too many open files" errors for tests that run later in the sequence.

The fix properly deletes all leaked Orch objects before clearing gDirectory in each test fixture's TearDown/deinitOrch:

- portsorch_ut.cpp: delete FlexCounterOrch
- routeorch_ut.cpp: delete MuxOrch, TunnelDecapOrch, FlexCounterOrch, FlowCounterRouteOrch
- qosorch_ut.cpp: delete FlexCounterOrch
- bufferorch_ut.cpp: delete FlexCounterOrch
- fdborch/flush_syncd_notif_ut.cpp: delete VxlanTunnelOrch
- intfsorch_ut.cpp: delete MuxOrch, TunnelDecapOrch, FlexCounterOrch, VNetOrch, VNetCfgRouteOrch, VNetRouteOrch
- flowcounterrouteorch_ut.cpp: delete MuxOrch, TunnelDecapOrch, FlexCounterOrch, VNetOrch, VNetCfgRouteOrch, VNetRouteOrch
- mux_rollback_ut.cpp: add BufferOrch to ut_orch_list for proper reverse-order deletion

For TunnelDecapOrch (not stored in gDirectory), promote the local variable to a class member (m_tunnel_decap_orch) in 3 fixtures (routeorch_ut, intfsorch_ut, flowcounterrouteorch_ut) to enable proper cleanup.

Tested: 119/119 tests PASSED with zero "Too many open files" errors.

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

**Why I did it**

**How I verified it**

**Details if related**
