### PR TITLE
[neighsyncd] Add TTL cache to suppress redundant neighbor deletes

### DIFF
--- a/neighsyncd/neighsync.cpp
+++ b/neighsyncd/neighsync.cpp
@@ -25,6 +25,25 @@ using namespace swss;
 #define SHORT_NAME_ETH_PREFIX "Eth"
 #define DEFAULT_VRF         "default"
 
+const int SUPPRESS_TTL = 60; // seconds
+
+void NeighSync::pruneSuppressCache()
+{
+    auto now = time(nullptr);
+    for (auto it = m_suppressDelCache.begin(); it != m_suppressDelCache.end(); )
+    {
+        if (now - it->second > SUPPRESS_TTL * 2)
+            it = m_suppressDelCache.erase(it);
+        else
+            ++it;
+    }
+}
+
+void NeighSync::clearSuppressCache()
+{
+    m_suppressDelCache.clear();
+}
+
 NeighSync::NeighSync(RedisPipeline *pipelineAppDB, DBConnector *stateDb, DBConnector *cfgDb) :
     m_neighTable(pipelineAppDB, APP_NEIGH_TABLE_NAME),
     m_stateNeighRestoreTable(stateDb, STATE_NEIGH_RESTORE_TABLE_NAME),
@@ -279,10 +298,24 @@ void NeighSync::onMsgNbr(int nlmsg_type, struct nl_object *obj)
     {
         if (delete_key == true)
         {
+            // Suppress redundant delete
+            auto now = time(nullptr);
+            auto it = m_suppressDelCache.find(key);
+
+            if (it != m_suppressDelCache.end() && (now - it->second) < SUPPRESS_TTL)
+            {
+                SWSS_LOG_INFO("Suppressing del for unresolved neighbor %s", key.c_str());
+                return;
+            }
+
+            // Proceed with delete and update cache
             m_neighTable.del(key);
+            m_suppressDelCache[key] = now;
+
             return;
         }
         m_neighTable.set(key, fvVector);
+        m_suppressDelCache.erase(key);
     }
 }
 

--- a/neighsyncd/neighsync.h
+++ b/neighsyncd/neighsync.h
@@ -1,6 +1,8 @@
 #ifndef __NEIGHSYNC__
 #define __NEIGHSYNC__
 
+#include <unordered_map>
+#include <ctime>
 #include "dbconnector.h"
 #include "producerstatetable.h"
 #include "netmsg.h"
@@ -35,6 +37,9 @@ public:
         return m_AppRestartAssist;
     }
 
+    void pruneSuppressCache();
+    void clearSuppressCache();
+
 private:
     Table m_stateNeighRestoreTable, m_cfgPeerSwitchTable;
     ProducerStateTable m_neighTable;
@@ -47,6 +52,8 @@ private:
     void onMsgNbr(int nlmsg_type, struct nl_object *obj);
     void onMsgLink(int nlmsg_type, struct nl_object *obj);
     std::map<std::string, int> m_intf_master;
+
+    std::unordered_map<std::string, time_t> m_suppressDelCache;
 };
 
 }

--- a/neighsyncd/neighsyncd.cpp
+++ b/neighsyncd/neighsyncd.cpp
@@ -7,9 +7,13 @@
 #include "netdispatcher.h"
 #include "netlink.h"
 #include "neighsyncd/neighsync.h"
+#include "selectabletimer.h"
 
 using namespace std;
 using namespace swss;
+
+// Register a 30 sec timer
+SelectableTimer pruneTimer(timespec{30, 0});
 
 int main(int argc, char **argv)
 {
@@ -70,11 +74,23 @@ int main(int argc, char **argv)
             netlink.dumpRequest(RTM_GETNEIGH);
             netlink.dumpRequest(RTM_GETLINK);
 
+            sync.clearSuppressCache();
+
             s.addSelectable(&netlink);
+            pruneTimer.start();
+            s.addSelectable(&pruneTimer);
+
             while (true)
             {
                 Selectable *temps;
                 s.select(&temps);
+
+                if (temps == &pruneTimer)
+                {
+                    sync.pruneSuppressCache();
+                    continue;
+                }
+
                 /*
                  * If warmstart is in progress, we check the reconcile timer,
                  * if timer expired, we stop the timer and start the reconcile process


### PR DESCRIPTION
- Why I did it
When many packets arrive with destination IPs in a connected route but no resolved neighbors (hosts don't exist), the kernel sends constant netlink FAILED events. neighsyncd translates each into a DEL record in APPL_DB, causing orchagent to be overwhelmed with redundant delete operations, filling swss.rec with noise.

- How I did it
Introduce a TTL-based suppression cache in neighsyncd. If a DEL for the same neighbor key was already issued within the last 60 seconds, subsequent DELs are suppressed. A 30-second periodic timer prunes stale entries (>120s old). When a neighbor transitions to a valid state (set), the cache entry is cleared so future deletes are not incorrectly suppressed.

- `neighsync.h`: Add `m_suppressDelCache` map + public `pruneSuppressCache()` / `clearSuppressCache()` methods
- `neighsync.cpp`: Add suppression logic around `m_neighTable.del()`, clear cache on `m_neighTable.set()`
- `neighsyncd.cpp`: Add `SelectableTimer` (30s) to periodically prune the cache; clear cache on restart

- How I verified it
Check CPU
