### PR TITLE
Fix Consumer priority propagation and queue starvation

### DIFF
--- a/cfgmgr/intfmgr.cpp
+++ b/cfgmgr/intfmgr.cpp
@@ -58,11 +58,13 @@ IntfMgr::IntfMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, c
     auto subscriberStateTable = new swss::SubscriberStateTable(stateDb,
             STATE_PORT_TABLE_NAME, TableConsumable::DEFAULT_POP_BATCH_SIZE, 100);
     auto stateConsumer = new Consumer(subscriberStateTable, this, STATE_PORT_TABLE_NAME);
+    stateConsumer->setPri(100);
     Orch::addExecutor(stateConsumer);
 
     auto subscriberStateLagTable = new swss::SubscriberStateTable(stateDb,
             STATE_LAG_TABLE_NAME, TableConsumable::DEFAULT_POP_BATCH_SIZE, 200);
     auto stateLagConsumer = new Consumer(subscriberStateLagTable, this, STATE_LAG_TABLE_NAME);
+    stateLagConsumer->setPri(200);
     Orch::addExecutor(stateLagConsumer);
 
     if (!WarmStart::isWarmStart())

--- a/orchagent/orch.cpp
+++ b/orchagent/orch.cpp
@@ -248,6 +248,17 @@ void Consumer::execute()
     {
         std::deque<KeyOpFieldsValuesTuple> entries;
         table->pops(entries);
+
+        if (entries.empty())
+        {
+            auto *selectable = getSelectable();
+            while (selectable->hasData())
+            {
+                selectable->updateAfterRead();
+            }
+            break;
+        }
+
         update_size = addToSync(entries);
     } while (update_size != 0);
 
@@ -783,14 +794,17 @@ bool Orch::isItemIdsMapContinuous(unsigned long idsMap, sai_uint32_t maxId)
 
 void Orch::addConsumer(DBConnector *db, string tableName, int pri)
 {
+    Consumer *consumer;
     if (db->getDbId() == CONFIG_DB || db->getDbId() == STATE_DB || db->getDbId() == CHASSIS_APP_DB)
     {
-        addExecutor(new Consumer(new SubscriberStateTable(db, tableName, TableConsumable::DEFAULT_POP_BATCH_SIZE, pri), this, tableName));
+        consumer = new Consumer(new SubscriberStateTable(db, tableName, TableConsumable::DEFAULT_POP_BATCH_SIZE, pri), this, tableName);
     }
     else
     {
-        addExecutor(new Consumer(new ConsumerStateTable(db, tableName, gBatchSize, pri), this, tableName));
+        consumer = new Consumer(new ConsumerStateTable(db, tableName, gBatchSize, pri), this, tableName);
     }
+    consumer->setPri(pri);
+    addExecutor(consumer);
 }
 
 void Orch::addExecutor(Executor* executor)

--- a/tests/mock_tests/consumer_ut.cpp
+++ b/tests/mock_tests/consumer_ut.cpp
@@ -3,6 +3,8 @@
 #include "mock_table.h"
 
 #include <sstream>
+#include <unistd.h>  /* pipe(), close() */
+#include "select.h" /* swss::Select */
 
 extern PortsOrch *gPortsOrch;
 
@@ -10,6 +12,65 @@ namespace consumer_test
 {
     using namespace std;
 
+    // -----------------------------------------------------------------------
+    // MockSelectable: lightweight Selectable backed by a real pipe(2) fd so
+    // that Select::addSelectable() / epoll_ctl() succeed without Redis.
+    //
+    // initializedWithData() returns true → the object is inserted into
+    // Select::m_ready immediately at addSelectable() time, without waiting
+    // for an epoll_wait() event.  This lets us pre-populate m_ready with
+    // multiple items at controlled priorities and then drain them with
+    // select(timeout=0) to verify the priority-sorted dispatch order.
+    // -----------------------------------------------------------------------
+    class MockSelectable : public swss::Selectable
+    {
+    public:
+        MockSelectable(int pri, const std::string &name)
+            : swss::Selectable(pri), m_name(name), m_hasData(true)
+        {
+            if (pipe(m_fds) != 0)
+                throw std::runtime_error("pipe() failed in MockSelectable");
+        }
+
+        ~MockSelectable()
+        {
+            close(m_fds[0]);
+            close(m_fds[1]);
+        }
+
+        int      getFd()             override { return m_fds[0]; }
+        uint64_t readData()          override { return 0; }
+        bool     hasData()           override { return m_hasData; }
+        bool     hasCachedData()     override { return false; }
+        bool     initializedWithData() override { return m_hasData; }
+        void     updateAfterRead()   override { m_hasData = false; }
+
+        const std::string &name() const { return m_name; }
+
+    private:
+        int         m_fds[2];
+        std::string m_name;
+        bool        m_hasData;
+    };
+
+    class TestOrch : public Orch
+    {
+    public:
+        TestOrch(swss::DBConnector *db, string tableName)
+            :Orch(db, tableName),
+            m_notification_count(0)
+        {
+        }
+
+        void doTask(Consumer& consumer)
+        {
+            std::cout << "TestOrch::doTask " << consumer.m_toSync.size() << std::endl;
+            m_notification_count += consumer.m_toSync.size();
+            consumer.m_toSync.clear();
+        }
+
+        long m_notification_count;
+    };
     struct ConsumerTest : public ::testing::Test
     {
         shared_ptr<swss::DBConnector> m_app_db;
@@ -321,5 +382,111 @@ namespace consumer_test
         exp_kofv = entryb;
         validate_syncmap(consumer->m_toSync, 1, key, exp_kofv);
 
+    }
+
+    // This test verifies that the Executor-layer priority matches the value
+    // passed to addConsumer().
+    TEST_F(ConsumerTest, AddConsumer_ExecutorPriorityPropagated)
+    {
+        const int kTestPri = 42;
+
+        // PriTestOrch uses Orch(db, tableName, pri) ctor which calls
+        // addConsumer(db, tableName, pri) internally.
+        struct PriTestOrch : public Orch
+        {
+            PriTestOrch(swss::DBConnector *db, const string &tbl, int pri)
+                : Orch(db, tbl, pri) {}
+            void doTask(Consumer &c) override { c.m_toSync.clear(); }
+        };
+
+        PriTestOrch orch(m_app_db.get(), "APPL_PRIO_TABLE", kTestPri);
+        Executor *executor = orch.getExecutor("APPL_PRIO_TABLE");
+
+        ASSERT_NE(executor, nullptr);
+        // The Consumer Executor priority must equal kTestPri.
+        // Before the fix this returned 0 regardless of the requested priority.
+        EXPECT_EQ(executor->getPri(), kTestPri);
+    }
+
+    // This test verifies that a single execute() with an empty key-set drains
+    // the entire inflated counter, leaving hasData() == false.
+    TEST_F(ConsumerTest, ConsumerExecute_DrainsInflatedQueueLength)
+    {
+        const long long kInflatedQueueLen = 500;
+
+        TestOrch test_orch(m_config_db.get(), "CFG_DRAIN_TABLE");
+        // Create a standalone ConsumerStateTable and Consumer for this test.
+        // The table is backed by an empty mock DB so pops() returns nothing.
+        auto *table = new swss::ConsumerStateTable(
+            m_config_db.get(), "CFG_DRAIN_TABLE", 1, 1);
+        Consumer test_consumer(table, &test_orch, "CFG_DRAIN_TABLE");
+
+        // Ensure the mock key-set is empty so pops() returns an empty deque.
+        ::testing_db::reset();
+
+        // Artificially inflate m_queueLength to simulate a PUBLISH burst whose
+        // notifications outpace the key consumption by pops().
+        table->setQueueLength(kInflatedQueueLen);
+        ASSERT_TRUE(test_consumer.hasData());
+        ASSERT_TRUE(test_consumer.hasCachedData());
+
+        // A single execute() must drain the entire inflated counter.
+        test_consumer.execute();
+
+        // After the fix m_queueLength == 0: the consumer is removed from
+        // Select::m_ready, stopping the idle-spin that starved other consumers.
+        EXPECT_FALSE(test_consumer.hasData());
+        EXPECT_FALSE(test_consumer.hasCachedData());
+    }
+
+
+    // This test validates the full Select::m_ready ordering path:
+    //
+    //   addConsumer(pri=X)  →  consumer->setPri(X)  →  Executor::getPri()==X
+    //                       →  Select::m_ready sorted by getPri() desc
+    //                       →  select() returns highest-priority object first
+    TEST_F(ConsumerTest, SelectPriorityOrder_HigherPriorityFirstDispatched)
+    {
+        swss::Select sel;
+
+        // Create three selectables with distinct priorities.
+        MockSelectable low  ( 5, "low_pri_5");
+        MockSelectable mid  (20, "mid_pri_20");
+        MockSelectable high (200, "high_pri_200");
+
+        // Register in intentionally reverse-priority order to prove that
+        // dispatch order depends on priority, not insertion order.
+        sel.addSelectable(&low);
+        sel.addSelectable(&high);
+        sel.addSelectable(&mid);
+
+        // All three objects are now in Select::m_ready (via initializedWithData()).
+        // select(timeout=0) polls epoll immediately (returns 0 new fd events)
+        // and then drains m_ready in priority-sorted order.
+        std::vector<std::string> dispatch_order;
+        swss::Selectable *s = nullptr;
+        int ret;
+
+        ret = sel.select(&s, 0);
+        ASSERT_EQ(ret, swss::Select::OBJECT);
+        dispatch_order.push_back(static_cast<MockSelectable*>(s)->name());
+
+        ret = sel.select(&s, 0);
+        ASSERT_EQ(ret, swss::Select::OBJECT);
+        dispatch_order.push_back(static_cast<MockSelectable*>(s)->name());
+
+        ret = sel.select(&s, 0);
+        ASSERT_EQ(ret, swss::Select::OBJECT);
+        dispatch_order.push_back(static_cast<MockSelectable*>(s)->name());
+
+        // Fourth call must return TIMEOUT — m_ready is empty.
+        ret = sel.select(&s, 0);
+        EXPECT_EQ(ret, swss::Select::TIMEOUT);
+
+        // Highest priority (200) must be dispatched first, lowest (5) last.
+        ASSERT_EQ(dispatch_order.size(), 3u);
+        EXPECT_EQ(dispatch_order[0], "high_pri_200");
+        EXPECT_EQ(dispatch_order[1], "mid_pri_20");
+        EXPECT_EQ(dispatch_order[2], "low_pri_5");
     }
 }


### PR DESCRIPTION
**What I did**

- Propagated the configured priority to the Consumer Executor in
  `Orch::addConsumer()`.
- Set the IntfMgr `STATE_PORT` and `STATE_LAG` Consumer priorities to
  100 and 200 respectively.
- Drained stale selectable notifications when `pops()` returns no
  entries.
- Added unit tests for Executor priority propagation, queue-counter
  draining, and priority-based Select dispatch ordering.

**Why I did it**

The priority passed to the Consumer table was not propagated to the
outer Consumer Executor. As a result, the Executor retained the
default priority of 0.

In addition, batched key processing could leave the RedisSelect
notification counter artificially inflated. This kept the Consumer in
the ready queue and could starve lower-priority events.

**How I verified it**

- Resolved the 202311.X cherry-pick conflicts.
- Verified that no conflict markers remain.
- `git diff --check` passed.