### PR TITLE
[portmgr] Remove unreachable mtu_slowpath block in setPortMtu()

### DIFF
--- a/cfgmgr/portmgr.cpp
+++ b/cfgmgr/portmgr.cpp
@@ -50,29 +50,6 @@ bool PortMgr::setPortMtu(const string &alias, const string &mtu)
     {
         throw runtime_error(cmd_str + " : " + res);
     }
-    vector<FieldValueTuple> temp;
-
-    /* 'mtu_slowpath' has higher priority than 'mtu' for the netdev mtu in kernel */
-    if (m_cfgPortTable.get(alias, temp))
-    {
-        auto mtu_slowpath = swss::fvsGetValue(temp, "mtu_slowpath", true);
-        if (!mtu_slowpath)
-        {
-            // ip link set dev <port_name> mtu <mtu>
-            cmd << IP_CMD << " link set dev " << shellquote(alias) << " mtu " << shellquote(mtu);
-            EXEC_WITH_ERROR_THROW(cmd.str(), res);
-
-        }
-    }
-
-    // Set the port MTU in application database to update both
-    // the port MTU and possibly the port based router interface MTU
-    vector<FieldValueTuple> fvs;
-    FieldValueTuple fv("mtu", mtu);
-    fvs.push_back(fv);
-    m_appPortTable.set(alias, fvs);
-
-    return true;
 }
 
 bool PortMgr::setPortMtuSlowpath(const string &alias, const string &mtu_slowpath)


### PR DESCRIPTION
Why I did it
------------
While investigating a customer issue (SONIC-14580: LLDP failure on
Ethernet50 after boot on AS4630-54PE) and diffing the Edgecore fork
against upstream sonic-net/sonic-swss, we noticed an unrelated dead
code issue in `cfgmgr/portmgr.cpp`'s `PortMgr::setPortMtu()`. This PR
addresses only that dead code as a standalone cleanup; it is **not**
a fix for SONIC-14580 and does not change any runtime behavior.

Before this fix, the function looked like:

```cpp
bool PortMgr::setPortMtu(const string &alias, const string &mtu)
{
    ...
    int ret = swss::exec(cmd_str, res);
    if (!ret)
    {
        return writeConfigToAppDb(alias, "mtu", mtu);
    }
    else if (!isPortStateOk(alias))
    {
        SWSS_LOG_WARN(...);
        return false;
    }
    else
    {
        throw runtime_error(cmd_str + " : " + res);
    }
    vector<FieldValueTuple> temp;                      // <-- unreachable from here on

    /* 'mtu_slowpath' has higher priority than 'mtu' for the netdev mtu in kernel */
    if (m_cfgPortTable.get(alias, temp))
    {
        auto mtu_slowpath = swss::fvsGetValue(temp, "mtu_slowpath", true);
        if (!mtu_slowpath)
        {
            cmd << IP_CMD << " link set dev " << shellquote(alias) << " mtu " << shellquote(mtu);
            EXEC_WITH_ERROR_THROW(cmd.str(), res);
        }
    }

    vector<FieldValueTuple> fvs;
    FieldValueTuple fv("mtu", mtu);
    fvs.push_back(fv);
    m_appPortTable.set(alias, fvs);

    return true;
}
```

Every branch of the `if / else if / else` chain either `return`s or
`throw`s, so everything starting at `vector<FieldValueTuple> temp;`
(the mtu_slowpath handling block and the trailing `return true;`) is
unreachable dead code. This looks like a merge artifact: Edgecore's
`mtu_slowpath` handling was originally appended after a simpler
error-handling chain, and a later merge of upstream's stricter
error handling (which now covers all cases) landed on top of it
without removing the now-dead tail.

**This removal does not remove the mtu_slowpath feature.** It is
served independently by `PortMgr::setPortMtuSlowpath()`, which is
called from `PortMgr::doTask()`:

```cpp
if (!mtu.empty())
{
    setPortMtu(alias, mtu);
    SWSS_LOG_NOTICE("Configure %s MTU to %s", alias.c_str(), mtu.c_str());
}

if (!mtu_slowpath.empty())
{
    setPortMtuSlowpath(alias, mtu_slowpath);
    SWSS_LOG_NOTICE("Configure %s slowpath MTU to %s", alias.c_str(), mtu_slowpath.c_str());
}
```

`setPortMtu()` and `setPortMtuSlowpath()` are separate call paths in
`doTask()`, so the dead block inside `setPortMtu()` was always a
redundant, unreachable duplicate of logic that `setPortMtuSlowpath()`
already performs on its own call path.

We also diffed against upstream sonic-net/sonic-swss 202311
(`cfgmgr/portmgr.cpp`), which has no `mtu_slowpath` feature at all:
its `setPortMtu()` ends immediately after the `else`/`throw`, with no
trailing code. This confirms the dead block is an Edgecore-only
leftover from an imperfect merge, not something upstream code
expects or depends on.

How I did it
------------
Removed the unreachable block (the `mtu_slowpath` handling and the
trailing `return true;`) after the `if / else if / else` chain in
`PortMgr::setPortMtu()`. No other logic was touched.

On the "does removing the trailing return cause a compiler warning"
question: since all three branches of the `if/else if/else` chain
already `return` or `throw`, GCC's flow analysis does not flag
"control reaches end of non-void function" for this shape. We
verified this directly with a minimal reproduction of the same
control-flow shape, compiled with
`g++ -std=c++17 -Wall -Wextra -Wreturn-type -c`: no such warning was
produced. Given that, we chose the minimal, safe fix of just deleting
the dead code rather than adding a redundant trailing `return`/`throw`
that would itself be unreachable.

How to verify it
-----------------
- Code review: confirm every branch of the `if/else if/else` chain in
  `setPortMtu()` returns or throws, so the removed tail was provably
  unreachable.
- Confirm `doTask()` still calls `setPortMtuSlowpath()` independently
  for the `mtu_slowpath` field (unchanged by this PR), so the feature
  continues to work as before.
- Build sonic-swss and confirm no new compiler warnings
  (specifically no "control reaches end of non-void function" for
  `setPortMtu()`).
- This is a pure code cleanup with no behavior change: the removed
  code was never executed before this change, so there is no
  functional regression to test for. Not related to and does not fix
  SONIC-14580.
